### PR TITLE
More flexible sparsity interface

### DIFF
--- a/ctldl/factor_data/empty_factor_data_left.hpp
+++ b/ctldl/factor_data/empty_factor_data_left.hpp
@@ -9,7 +9,7 @@ namespace ctldl {
 
 template <class FactorData>
 struct EmptyFactorDataLeft {
-  static constexpr auto num_rows = FactorData::sparsity.num_rows;
+  static constexpr auto num_rows = FactorData::sparsity.numRows();
   using Value = typename FactorData::Value;
   static constexpr auto sparsity = makeEmptySparsityCSR<num_rows, 0>();
   static constexpr std::array<Value, 0> L{};

--- a/ctldl/factor_data/factorization.hpp
+++ b/ctldl/factor_data/factorization.hpp
@@ -21,12 +21,12 @@
 namespace ctldl {
 
 template <Sparsity sparsity_orig, class Value_,
-          Permutation<sparsity_orig.num_rows> permutation_in =
+          Permutation<sparsity_orig.numRows()> permutation_in =
               PermutationIdentity{}>
 class Factorization {
  public:
   static_assert(isSquare(sparsity_orig));
-  static constexpr auto dim = std::size_t{sparsity_orig.num_rows};
+  static constexpr auto dim = std::size_t{sparsity_orig.numRows()};
   using Value = Value_;
   static constexpr auto permutation = permutation_in;
 
@@ -60,7 +60,7 @@ class Factorization {
 
   static constexpr auto sparsity =
       SparsityCSR(getFilledInSparsity<sparsity_orig, permutation>());
-  static constexpr auto nnz = std::size_t{sparsity.nnz};
+  static constexpr auto nnz = std::size_t{sparsity.nnz()};
   static constexpr auto permutation_row = permutation;
   static constexpr auto permutation_col = permutation;
 

--- a/ctldl/factor_data/factorization_repeating_block_tridiagonal.hpp
+++ b/ctldl/factor_data/factorization_repeating_block_tridiagonal.hpp
@@ -24,28 +24,28 @@ namespace ctldl {
 // [      B  A  B']
 // [         B  A ]
 template <Sparsity sparsity_A, Sparsity sparsity_B, class Value_,
-          Permutation<sparsity_A.num_rows> permutation_in =
+          Permutation<sparsity_A.numRows()> permutation_in =
               PermutationIdentity{}>
 class FactorizationRepeatingBlockTridiagonal {
  private:
   static_assert(isSquare(sparsity_A));
   static_assert(isSquare(sparsity_B));
-  static_assert(sparsity_B.num_rows == sparsity_A.num_rows);
+  static_assert(sparsity_B.numRows() == sparsity_A.numRows());
 
   static constexpr auto sparsity_to_factorize =
       SparsityToFactorizeTridiagonalArrowheadLinked{
-          makeEmptySparsityToFactorizeStart<0, sparsity_A.num_rows, 0>(),
+          makeEmptySparsityToFactorizeStart<0, sparsity_A.numRows(), 0>(),
           SparsityToFactorizeTridiagonal{sparsity_A, sparsity_B,
                                          permutation_in},
-          makeEmptySparsityToFactorizeLink<sparsity_A.num_cols, 0, 0>(),
-          makeEmptySparsityToFactorizeOuter<sparsity_A.num_cols, 0>()};
+          makeEmptySparsityToFactorizeLink<sparsity_A.numCols(), 0, 0>(),
+          makeEmptySparsityToFactorizeOuter<sparsity_A.numCols(), 0>()};
   using Base = FactorizationRepeatingBlockTridiagonalArrowheadLinked<
       sparsity_to_factorize, Value_>;
   Base m_base;
 
  public:
   using Value = Value_;
-  static constexpr auto dim = std::size_t{sparsity_A.num_rows};
+  static constexpr auto dim = std::size_t{sparsity_A.numRows()};
 
   explicit FactorizationRepeatingBlockTridiagonal(
       const std::size_t num_repetitions)

--- a/ctldl/factor_data/factorization_subdiagonal_block.hpp
+++ b/ctldl/factor_data/factorization_subdiagonal_block.hpp
@@ -17,16 +17,16 @@
 namespace ctldl {
 
 template <Sparsity sparsity_in, class Value_,
-          Permutation<sparsity_in.num_rows> permutation_row_in =
+          Permutation<sparsity_in.numRows()> permutation_row_in =
               PermutationIdentity{},
-          Permutation<sparsity_in.num_cols> permutation_col_in =
+          Permutation<sparsity_in.numCols()> permutation_col_in =
               PermutationIdentity{}>
 class FactorizationSubdiagonalBlock {
  public:
   static constexpr auto sparsity = makeSparsityCSR(sparsity_in);
-  static constexpr auto nnz = std::size_t{sparsity.nnz};
-  static constexpr auto num_rows = std::size_t{sparsity.num_rows};
-  static constexpr auto num_cols = std::size_t{sparsity.num_cols};
+  static constexpr auto nnz = std::size_t{sparsity.nnz()};
+  static constexpr auto num_rows = std::size_t{sparsity.numRows()};
+  static constexpr auto num_cols = std::size_t{sparsity.numCols()};
   using Value = Value_;
   static constexpr auto permutation_row = permutation_row_in;
   static constexpr auto permutation_col = permutation_col_in;

--- a/ctldl/factor_data/sparsity_to_factorize_link.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_link.hpp
@@ -43,9 +43,9 @@ template <class Prev, class Diag, class Next,
           class PermutationIn = PermutationIdentity>
 SparsityToFactorizeLink(Prev, Diag, Next, PermutationIn = PermutationIdentity{})
     -> SparsityToFactorizeLink<
-        ctad_t<Sparsity, Prev>::num_cols, ctad_t<Sparsity, Diag>::num_rows,
-        ctad_t<Sparsity, Next>::num_rows, ctad_t<Sparsity, Prev>::nnz,
-        ctad_t<Sparsity, Diag>::nnz, ctad_t<Sparsity, Next>::nnz>;
+        ctad_t<Sparsity, Prev>::numCols(), ctad_t<Sparsity, Diag>::numRows(),
+        ctad_t<Sparsity, Next>::numRows(), ctad_t<Sparsity, Prev>::nnz(),
+        ctad_t<Sparsity, Diag>::nnz(), ctad_t<Sparsity, Next>::nnz()>;
 
 template <std::size_t dim_prev, std::size_t dim_link, std::size_t dim_next>
 constexpr auto makeEmptySparsityToFactorizeLink() {

--- a/ctldl/factor_data/sparsity_to_factorize_outer.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_outer.hpp
@@ -46,8 +46,8 @@ struct SparsityToFactorizeOuter {
 template <class Subdiag, class Diag, class PermutationIn = PermutationIdentity>
 SparsityToFactorizeOuter(Subdiag, Diag, PermutationIn = PermutationIdentity{})
     -> SparsityToFactorizeOuter<
-        ctad_t<Sparsity, Subdiag>::num_cols, ctad_t<Sparsity, Diag>::num_rows,
-        ctad_t<Sparsity, Subdiag>::nnz, ctad_t<Sparsity, Diag>::nnz>;
+        ctad_t<Sparsity, Subdiag>::numCols(), ctad_t<Sparsity, Diag>::numRows(),
+        ctad_t<Sparsity, Subdiag>::nnz(), ctad_t<Sparsity, Diag>::nnz()>;
 
 template <std::size_t dim_inner, std::size_t dim_outer>
 constexpr auto makeEmptySparsityToFactorizeOuter() {

--- a/ctldl/factor_data/sparsity_to_factorize_start.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_start.hpp
@@ -44,9 +44,9 @@ template <class Diag, class Next, class Outer,
 SparsityToFactorizeStart(Diag, Next, Outer,
                          PermutationIn = PermutationIdentity{})
     -> SparsityToFactorizeStart<
-        ctad_t<Sparsity, Diag>::num_rows, ctad_t<Sparsity, Next>::num_rows,
-        ctad_t<Sparsity, Outer>::num_rows, ctad_t<Sparsity, Diag>::nnz,
-        ctad_t<Sparsity, Next>::nnz, ctad_t<Sparsity, Outer>::nnz>;
+        ctad_t<Sparsity, Diag>::numRows(), ctad_t<Sparsity, Next>::numRows(),
+        ctad_t<Sparsity, Outer>::numRows(), ctad_t<Sparsity, Diag>::nnz(),
+        ctad_t<Sparsity, Next>::nnz(), ctad_t<Sparsity, Outer>::nnz()>;
 
 template <std::size_t dim_start, std::size_t dim_next, std::size_t dim_outer>
 constexpr auto makeEmptySparsityToFactorizeStart() {

--- a/ctldl/factor_data/sparsity_to_factorize_tridiagonal.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_tridiagonal.hpp
@@ -38,8 +38,8 @@ template <class SparsityDiag, class SparsitySubdiag,
           class PermutationIn = PermutationIdentity>
 SparsityToFactorizeTridiagonal(SparsityDiag, SparsitySubdiag,
                                PermutationIn = PermutationIdentity{})
-    -> SparsityToFactorizeTridiagonal<ctad_t<Sparsity, SparsityDiag>::num_rows,
-                                      ctad_t<Sparsity, SparsityDiag>::nnz,
-                                      ctad_t<Sparsity, SparsitySubdiag>::nnz>;
+    -> SparsityToFactorizeTridiagonal<ctad_t<Sparsity, SparsityDiag>::numRows(),
+                                      ctad_t<Sparsity, SparsityDiag>::nnz(),
+                                      ctad_t<Sparsity, SparsitySubdiag>::nnz()>;
 
 }  // namespace ctldl

--- a/ctldl/factorize/factor_initialization.hpp
+++ b/ctldl/factorize/factor_initialization.hpp
@@ -17,12 +17,12 @@ struct FactorInitNone {
 template <std::size_t entry_index, class Init, class FactorData>
 auto getInitialFactorValuePlainL(const Init& init, const FactorData& factor) {
   constexpr auto& sparsity = FactorData::sparsity;
-  if constexpr (std::is_same_v<Init, FactorInitNone<sparsity.num_rows,
-                                                    sparsity.num_cols>>) {
+  if constexpr (std::is_same_v<Init, FactorInitNone<sparsity.numRows(),
+                                                    sparsity.numCols()>>) {
     return factor.L[entry_index];
   } else {
-    constexpr auto i = std::size_t{sparsity.entries[entry_index].row_index};
-    constexpr auto j = std::size_t{sparsity.entries[entry_index].col_index};
+    constexpr auto i = std::size_t{sparsity.entries()[entry_index].row_index};
+    constexpr auto j = std::size_t{sparsity.entries()[entry_index].col_index};
     constexpr auto entry_orig = FactorData::origEntry({i, j});
     return getMatrixValueAt<entry_orig.row_index, entry_orig.col_index>(init);
   }
@@ -38,8 +38,8 @@ auto getInitialFactorValueL(const Init& init, const FactorData& factor) {
 template <std::size_t row_index, class Init, class FactorData>
 auto getInitialFactorValuePlainD(const Init& init, const FactorData& factor) {
   constexpr auto& sparsity = FactorData::sparsity;
-  if constexpr (std::is_same_v<Init, FactorInitNone<sparsity.num_rows,
-                                                    sparsity.num_cols>>) {
+  if constexpr (std::is_same_v<Init, FactorInitNone<sparsity.numRows(),
+                                                    sparsity.numCols()>>) {
     return factor.D[row_index];
   } else {
     constexpr auto row_index_orig = FactorData::origRowIndex(row_index);
@@ -57,8 +57,8 @@ auto getInitialFactorValueD(const Init& init, const FactorData& factor) {
 template <std::size_t row_index, class Init, class FactorData>
 void initializeFactorRow(const Init& init, FactorData& factor) {
   if constexpr (!std::is_same_v<
-                    Init, FactorInitNone<FactorData::sparsity.num_rows,
-                                         FactorData::sparsity.num_cols>>) {
+                    Init, FactorInitNone<FactorData::sparsity.numRows(),
+                                         FactorData::sparsity.numCols()>>) {
     fillRowWithOriginalMatrixValues<row_index>(init, factor);
   }
 }

--- a/ctldl/factorize/factorize_entry_wise.hpp
+++ b/ctldl/factorize/factorize_entry_wise.hpp
@@ -38,8 +38,8 @@ template <std::size_t entry_index_ij, class FactorData21, class Init21,
   constexpr auto& sparsity11 = FactorData11::sparsity;
   constexpr auto& sparsity21 = FactorData21::sparsity;
 
-  constexpr auto i = std::size_t{sparsity21.entries[entry_index_ij].row_index};
-  constexpr auto j = std::size_t{sparsity21.entries[entry_index_ij].col_index};
+  constexpr auto i = std::size_t{sparsity21.entries()[entry_index_ij].row_index};
+  constexpr auto j = std::size_t{sparsity21.entries()[entry_index_ij].col_index};
 
   auto Lij = getInitialFactorValueL<entry_index_ij>(init21, factor21);
 
@@ -65,8 +65,8 @@ template <std::size_t i, class FactorData21, class Init21, class FactorData11>
 [[gnu::always_inline]] inline void factorizeEntryWiseSubdiagonalImpl(
     FactorData21& factor21, const Init21& init21, const FactorData11& factor11) {
   constexpr auto& sparsity21 = FactorData21::sparsity;
-  constexpr auto row_begin = std::size_t{sparsity21.row_begin_indices[i]};
-  constexpr auto row_end = std::size_t{sparsity21.row_begin_indices[i + 1]};
+  constexpr auto row_begin = std::size_t{sparsity21.rowBeginIndices()[i]};
+  constexpr auto row_end = std::size_t{sparsity21.rowBeginIndices()[i + 1]};
   factorEntryWiseSubdiagonalImplRow(factor21, init21, factor11,
                                     makeIndexSequence<row_begin, row_end>());
 }
@@ -87,12 +87,12 @@ template <std::size_t i, class FactorData, class FactorDataDiag>
     const typename FactorData::Value value_init) {
   constexpr auto& sparsity = FactorData::sparsity;
 
-  constexpr auto row_begin = std::size_t{sparsity.row_begin_indices[i]};
-  constexpr auto row_end = std::size_t{sparsity.row_begin_indices[i + 1]};
+  constexpr auto row_begin = std::size_t{sparsity.rowBeginIndices()[i]};
+  constexpr auto row_end = std::size_t{sparsity.rowBeginIndices()[i + 1]};
   auto value = value_init;
   for (auto entry_index_ij = row_begin; entry_index_ij != row_end;
        ++entry_index_ij) {
-    const std::size_t j = sparsity.entries[entry_index_ij].col_index;
+    const std::size_t j = sparsity.entries()[entry_index_ij].col_index;
     value -= square(fact.L[entry_index_ij]) * diag.D[j];
   }
   return value;
@@ -132,8 +132,8 @@ template <std::size_t entry_index_ij, class FactorData22, class Init22,
   constexpr auto& sparsity21 = FactorData21::sparsity;
   constexpr auto& sparsity22 = FactorData22::sparsity;
 
-  constexpr auto i = std::size_t{sparsity22.entries[entry_index_ij].row_index};
-  constexpr auto j = std::size_t{sparsity22.entries[entry_index_ij].col_index};
+  constexpr auto i = std::size_t{sparsity22.entries()[entry_index_ij].row_index};
+  constexpr auto j = std::size_t{sparsity22.entries()[entry_index_ij].col_index};
 
   auto Lij = getInitialFactorValueL<entry_index_ij>(init22, factor22);
 
@@ -168,10 +168,10 @@ template <std::size_t i, class FactorData22, class Init22, class FactorData21,
     const FactorData11& factor11, const Regularization auto& regularization) {
   constexpr auto& sparsity21 = FactorData21::sparsity;
   constexpr auto& sparsity22 = FactorData22::sparsity;
-  static_assert(sparsity22.num_rows == sparsity21.num_rows);
+  static_assert(sparsity22.numRows() == sparsity21.numRows());
 
-  constexpr auto row_begin = std::size_t{sparsity22.row_begin_indices[i]};
-  constexpr auto row_end = std::size_t{sparsity22.row_begin_indices[i + 1]};
+  constexpr auto row_begin = std::size_t{sparsity22.rowBeginIndices()[i]};
+  constexpr auto row_end = std::size_t{sparsity22.rowBeginIndices()[i + 1]};
 
   auto Di = getInitialFactorValueD<i>(init22, factor22);
   Di = applyContributionsRowDiagonal<i>(factor21, factor11, Di);
@@ -222,7 +222,7 @@ void factorizeEntryWise(const FactorData11& factor11, const Init21& init21,
   static_assert(isSparsitySubset(Init21::sparsity, FactorData21::sparsity,
                                  FactorData21::permutation_row,
                                  FactorData21::permutation_col));
-  constexpr auto num_rows = std::size_t{FactorData22::sparsity.num_rows};
+  constexpr auto num_rows = std::size_t{FactorData22::sparsity.numRows()};
   factorizeEntryWiseSubdiagonalImpl(factor21, init21, factor11,
                                     std::make_index_sequence<num_rows>());
   factorizeEntryWiseImpl(factor22, init22, factor21, factor11, regularization,
@@ -243,7 +243,7 @@ void factorizeEntryWise(FactorData& factor, const Init& init,
                         const Regularization auto& regularization) {
   constexpr EmptyFactorDataLeft<FactorData> empty21;
   constexpr EmptyFactorDataDiagonal<decltype(empty21)> empty11;
-  constexpr EmptyMatrixInput<FactorData::sparsity.num_rows, 0> empty_init21;
+  constexpr EmptyMatrixInput<FactorData::sparsity.numRows(), 0> empty_init21;
   factorizeEntryWise(empty11, empty_init21, init, empty21, factor,
                      regularization);
 }

--- a/ctldl/factorize/factorize_up_looking.hpp
+++ b/ctldl/factorize/factorize_up_looking.hpp
@@ -28,8 +28,8 @@ namespace ctldl {
 template <std::size_t entry_index, class FactorData>
 [[gnu::always_inline]] inline auto factorizeUpLookingInnerSelf(
     FactorData& fact) {
-  constexpr auto i = FactorData::sparsity.entries[entry_index].row_index;
-  constexpr auto j = FactorData::sparsity.entries[entry_index].col_index;
+  constexpr auto i = FactorData::sparsity.entries()[entry_index].row_index;
+  constexpr auto j = FactorData::sparsity.entries()[entry_index].col_index;
 
   const auto Lij_scaled = fact.L[entry_index];
 
@@ -72,8 +72,8 @@ template <std::size_t entry_index, class FactorData11, class FactorData21,
 [[gnu::always_inline]] inline auto factorizeUpLookingInnerLeft(
     const FactorData11& factor11, FactorData21& factor21,
     FactorData22& factor22) {
-  constexpr auto i = FactorData21::sparsity.entries[entry_index].row_index;
-  constexpr auto j = FactorData21::sparsity.entries[entry_index].col_index;
+  constexpr auto i = FactorData21::sparsity.entries()[entry_index].row_index;
+  constexpr auto j = FactorData21::sparsity.entries()[entry_index].col_index;
 
   const auto Lij_scaled = factor21.L[entry_index];
 
@@ -120,8 +120,8 @@ template <std::size_t entry_index, class FactorData11, class FactorData21,
   constexpr auto& sparsity32 = FactorData32::sparsity;
   constexpr auto& sparsity33 = FactorData33::sparsity;
 
-  constexpr auto i = sparsity31.entries[entry_index].row_index;
-  constexpr auto j = sparsity31.entries[entry_index].col_index;
+  constexpr auto i = sparsity31.entries()[entry_index].row_index;
+  constexpr auto j = sparsity31.entries()[entry_index].col_index;
 
   const auto Lij_scaled = factor31.L[entry_index];
 
@@ -182,19 +182,19 @@ template <std::size_t i, class FactorData11, class Init21, class Init22,
     const Regularization auto& regularization) {
   constexpr auto& sparsity21 = FactorData21::sparsity;
   constexpr auto& sparsity22 = FactorData22::sparsity;
-  static_assert(sparsity22.num_rows == sparsity21.num_rows);
+  static_assert(sparsity22.numRows() == sparsity21.numRows());
 
   auto Di = getInitialFactorValueD<i>(init22, factor22);
 
   initializeFactorRow<i>(init21, factor21);
   initializeFactorRow<i>(init22, factor22);
 
-  constexpr auto row_begin21 = sparsity21.row_begin_indices[i];
-  constexpr auto row_end21 = sparsity21.row_begin_indices[i + 1];
+  constexpr auto row_begin21 = sparsity21.rowBeginIndices()[i];
+  constexpr auto row_end21 = sparsity21.rowBeginIndices()[i + 1];
   Di = factorizeUpLookingInnerLeft(factor11, factor21, factor22, Di,
                                    makeIndexSequence<row_begin21, row_end21>());
-  constexpr auto row_begin22 = sparsity22.row_begin_indices[i];
-  constexpr auto row_end22 = sparsity22.row_begin_indices[i + 1];
+  constexpr auto row_begin22 = sparsity22.rowBeginIndices()[i];
+  constexpr auto row_end22 = sparsity22.rowBeginIndices()[i + 1];
   Di = factorizeUpLookingInnerSelf(factor22, Di,
                                    makeIndexSequence<row_begin22, row_end22>());
   Di = regularization.regularize(Di, i);
@@ -242,7 +242,7 @@ void factorizeUpLooking(const FactorData11& factor11, const Init21& init21,
   static_assert(isSparsitySubset(Init21::sparsity, FactorData21::sparsity,
                                  FactorData21::permutation_row,
                                  FactorData21::permutation_col));
-  constexpr auto num_rows = std::size_t{FactorData22::sparsity.num_rows};
+  constexpr auto num_rows = std::size_t{FactorData22::sparsity.numRows()};
   factorizeUpLookingImpl(factor11, init21, init22, factor21, factor22,
                          regularization, std::make_index_sequence<num_rows>());
 }
@@ -261,7 +261,7 @@ void factorizeUpLooking(FactorData& factor, const Init& init,
                         const Regularization auto& regularization) {
   constexpr EmptyFactorDataLeft<FactorData> empty21;
   constexpr EmptyFactorDataDiagonal<decltype(empty21)> empty11;
-  constexpr EmptyMatrixInput<FactorData::sparsity.num_rows, 0> empty_init21;
+  constexpr EmptyMatrixInput<FactorData::sparsity.numRows(), 0> empty_init21;
   factorizeUpLooking(empty11, empty_init21, init, empty21, factor,
                      regularization);
 }
@@ -299,8 +299,8 @@ void factorizePartialUpLookingImpl(const FactorData11& factor11,
   initializeFactorRow<i>(init32, factor32);
   initializeFactorRow<i>(init33, factor33);
   auto Di = factor33.D[i];
-  constexpr auto row_begin31 = sparsity31.row_begin_indices[i];
-  constexpr auto row_end31 = sparsity31.row_begin_indices[i + 1];
+  constexpr auto row_begin31 = sparsity31.rowBeginIndices()[i];
+  constexpr auto row_end31 = sparsity31.rowBeginIndices()[i + 1];
   Di = factorizeUpLookingInnerLeft(factor11, factor21, factor31, factor32,
                                    factor33, Di,
                                    makeIndexSequence<row_begin31, row_end31>());
@@ -349,7 +349,7 @@ void factorizePartialUpLooking(const FactorData11& factor11,
                                const Init31& init31, const Init32& init32,
                                const Init33& init33, FactorData31& factor31,
                                FactorData32& factor32, FactorData33& factor33) {
-  constexpr auto num_rows = std::size_t{FactorData31::sparsity.num_rows};
+  constexpr auto num_rows = std::size_t{FactorData31::sparsity.numRows()};
   factorizePartialUpLookingImpl(factor11, factor21, init31, init32, init33,
                                 factor31, factor32, factor33,
                                 std::make_index_sequence<num_rows>());

--- a/ctldl/factorize/fill_with_original_matrix.hpp
+++ b/ctldl/factorize/fill_with_original_matrix.hpp
@@ -13,7 +13,7 @@ template <std::size_t entry_index, class Matrix, class FactorData>
     const Matrix& input, FactorData& fact) {
   using Value = typename FactorData::Value;
   constexpr auto entry_orig =
-      FactorData::origEntry(FactorData::sparsity.entries[entry_index]);
+      FactorData::origEntry(FactorData::sparsity.entries()[entry_index]);
   fact.L[entry_index] = static_cast<Value>(
       getMatrixValueAt<entry_orig.row_index, entry_orig.col_index>(input));
 }
@@ -36,8 +36,8 @@ template <std::size_t... EntryIndices, class Matrix, class FactorData>
 template <std::size_t i, class Matrix, class FactorData>
 [[gnu::always_inline]] inline auto fillRowWithOriginalMatrixValues(
     const Matrix& input, FactorData& fact) {
-  constexpr auto row_begin = FactorData::sparsity.row_begin_indices[i];
-  constexpr auto row_end = FactorData::sparsity.row_begin_indices[i + 1];
+  constexpr auto row_begin = FactorData::sparsity.rowBeginIndices()[i];
+  constexpr auto row_end = FactorData::sparsity.rowBeginIndices()[i + 1];
   fillRowWithOriginalMatrixValues(input, fact,
                                   makeIndexSequence<row_begin, row_end>());
 }
@@ -57,7 +57,7 @@ void fillWithOriginalMatrixValuesIncludingDiagonal(
 
 template <class Matrix, class FactorData>
 void fillWithOriginalMatrixValues(const Matrix& input, FactorData& fact) {
-  constexpr auto num_rows = std::size_t{FactorData::sparsity.num_rows};
+  constexpr auto num_rows = std::size_t{FactorData::sparsity.numRows()};
   fillWithOriginalMatrixValues(input, fact,
                                std::make_index_sequence<num_rows>());
 }
@@ -65,7 +65,7 @@ void fillWithOriginalMatrixValues(const Matrix& input, FactorData& fact) {
 template <class Matrix, class FactorData>
 void fillWithOriginalMatrixValuesIncludingDiagonal(const Matrix& input,
                                                    FactorData& fact) {
-  constexpr auto num_rows = std::size_t{FactorData::sparsity.num_rows};
+  constexpr auto num_rows = std::size_t{FactorData::sparsity.numRows()};
   fillWithOriginalMatrixValuesIncludingDiagonal(
       input, fact, std::make_index_sequence<num_rows>());
 }

--- a/ctldl/fileio/mtx_file_read_repeating_block_tridiagonal_arrowhead_linked.hpp
+++ b/ctldl/fileio/mtx_file_read_repeating_block_tridiagonal_arrowhead_linked.hpp
@@ -83,7 +83,7 @@ void mtxAddEntryLink(const MtxEntry entry, Matrix& matrix) {
 template <auto sparsity_in>
 struct MtxInputMatrix {
   static constexpr auto sparsity = SparsityCSR(sparsity_in);
-  std::array<double, sparsity.nnz> values = {};
+  std::array<double, sparsity.nnz()> values = {};
   double valueAt(const std::size_t entry_index) const {
     return values[entry_index];
   }

--- a/ctldl/matrix/multiply.hpp
+++ b/ctldl/matrix/multiply.hpp
@@ -11,10 +11,10 @@ template <MultiplyKind kind, class Matrix, class Solution, class Rhs>
 void multiply(const Matrix& matrix, const Solution& solution, Rhs&& rhs) {
   using ValueRhs = std::remove_reference_t<decltype(rhs[0])>;
 
-  constexpr auto nnz = std::size_t{Matrix::sparsity.entries.size()};
+  constexpr auto nnz = std::size_t{Matrix::sparsity.entries().size()};
   for (std::size_t entry_index = 0; entry_index < nnz; ++entry_index) {
-    const auto row_index = Matrix::sparsity.entries[entry_index].row_index;
-    const auto col_index = Matrix::sparsity.entries[entry_index].col_index;
+    const auto row_index = Matrix::sparsity.entries()[entry_index].row_index;
+    const auto col_index = Matrix::sparsity.entries()[entry_index].col_index;
     const auto value = matrix.valueAt(entry_index);
     if constexpr (kind & MultiplyKind::Normal) {
       rhs[row_index] += static_cast<ValueRhs>(value) *

--- a/ctldl/solve/solve_backward_substitution.hpp
+++ b/ctldl/solve/solve_backward_substitution.hpp
@@ -14,11 +14,11 @@ template <std::size_t i, class FactorData, class ValueSolution, class Vector>
   using ValueOut = std::remove_reference_t<decltype(partial_solution[0])>;
   constexpr auto& sparsity = FactorData::sparsity;
 
-  constexpr auto row_begin = std::size_t{sparsity.row_begin_indices[i]};
-  constexpr auto row_end = std::size_t{sparsity.row_begin_indices[i + 1]};
+  constexpr auto row_begin = std::size_t{sparsity.rowBeginIndices()[i]};
+  constexpr auto row_end = std::size_t{sparsity.rowBeginIndices()[i + 1]};
   for (auto entry_index_ij = row_begin; entry_index_ij != row_end;
        ++entry_index_ij) {
-    const std::size_t j = sparsity.entries[entry_index_ij].col_index;
+    const std::size_t j = sparsity.entries()[entry_index_ij].col_index;
     const auto j_orig = FactorData::origColIndex(j);
     partial_solution[j_orig] -= static_cast<ValueOut>(fact.L[entry_index_ij]) *
                                 static_cast<ValueOut>(solution_i);
@@ -73,7 +73,7 @@ template <class FactorData, class VectorSolution, class VectorPartialSolution>
 void solveBackwardSubstitution(const FactorData& factor_block,
                                const VectorSolution& solution,
                                VectorPartialSolution&& partial_solution) {
-  constexpr auto num_rows = std::size_t{FactorData::sparsity.num_rows};
+  constexpr auto num_rows = std::size_t{FactorData::sparsity.numRows()};
   solveBackwardSubstitutionImpl(factor_block, solution, partial_solution,
                                 makeIndexSequenceReversed<0, num_rows>());
 }

--- a/ctldl/solve/solve_forward_substitution.hpp
+++ b/ctldl/solve/solve_forward_substitution.hpp
@@ -12,12 +12,12 @@ template <std::size_t i, class FactorData, class Vector, class ValueOut>
     const FactorData& fact, const Vector& solution, const ValueOut init) {
   constexpr auto& sparsity = FactorData::sparsity;
 
-  constexpr auto row_begin = std::size_t{sparsity.row_begin_indices[i]};
-  constexpr auto row_end = std::size_t{sparsity.row_begin_indices[i + 1]};
+  constexpr auto row_begin = std::size_t{sparsity.rowBeginIndices()[i]};
+  constexpr auto row_end = std::size_t{sparsity.rowBeginIndices()[i + 1]};
   auto value = init;
   for (auto entry_index_ij = row_begin; entry_index_ij != row_end;
        ++entry_index_ij) {
-    const std::size_t j = sparsity.entries[entry_index_ij].col_index;
+    const std::size_t j = sparsity.entries()[entry_index_ij].col_index;
     const auto j_orig = FactorData::origColIndex(j);
     value -= static_cast<ValueOut>(fact.L[entry_index_ij]) *
              static_cast<ValueOut>(solution[j_orig]);
@@ -73,7 +73,7 @@ template <class FactorData, class VectorSolution, class VectorPartialSolution>
 void solveForwardSubstitution(const FactorData& factor_block,
                               const VectorSolution& solution,
                               VectorPartialSolution&& partial_solution) {
-  constexpr auto num_rows = std::size_t{FactorData::sparsity.num_rows};
+  constexpr auto num_rows = std::size_t{FactorData::sparsity.numRows()};
   solveForwardSubstitutionImpl(factor_block, solution, partial_solution,
                                std::make_index_sequence<num_rows>());
 }
@@ -83,8 +83,8 @@ template <std::size_t i, class FactorData, class Vector, class FactorDataLeft,
 [[gnu::always_inline]] inline auto solveForwardSubstitutionImpl(
     const FactorData& diag, const Vector& rhs_in_solution_out,
     const FactorDataLeft& left, const VectorLeft& solution_left) {
-  static_assert(FactorData::sparsity.num_rows ==
-                FactorDataLeft::sparsity.num_rows);
+  static_assert(FactorData::sparsity.numRows() ==
+                FactorDataLeft::sparsity.numRows());
   static_assert(FactorData::permutation == FactorDataLeft::permutation_row);
 
   constexpr auto i_orig = FactorData::origRowIndex(i);
@@ -136,7 +136,7 @@ void solveForwardSubstitution(const FactorData& diag,
                               Vector&& rhs_in_solution_out,
                               const FactorDataLeft& left,
                               const VectorLeft& solution_left) {
-  constexpr auto num_rows = std::size_t{FactorData::sparsity.num_rows};
+  constexpr auto num_rows = std::size_t{FactorData::sparsity.numRows()};
   solveForwardSubstitutionImpl(diag, rhs_in_solution_out, left, solution_left,
                                std::make_index_sequence<num_rows>());
 }

--- a/ctldl/sparsity/bool_matrix.hpp
+++ b/ctldl/sparsity/bool_matrix.hpp
@@ -17,15 +17,15 @@ namespace ctldl {
  * convenient way, where an entry is true if and only if there is a nonzero
  * entry in the matrix to be represented.
  */
-template <std::size_t num_rows_, std::size_t num_cols_>
+template <std::size_t num_rows, std::size_t num_cols>
 struct BoolMatrix {
-  static constexpr auto num_rows = num_rows_;
-  static constexpr auto num_cols = num_cols_;
-  std::array<std::array<bool, num_cols>, num_rows> values;
+  static constexpr std::size_t numRows() { return num_rows; }
+  static constexpr std::size_t numCols() { return num_cols; }
+  std::array<std::array<bool, numCols()>, numRows()> values;
   constexpr auto nnz() const {
     return std::accumulate(
         values.cbegin(), values.cend(), std::size_t{0},
-        [](const std::size_t carry, const std::array<bool, num_cols>& row) {
+        [](const std::size_t carry, const std::array<bool, numCols()>& row) {
           return carry +
                  static_cast<std::size_t>(std::ranges::count(row, true));
         });
@@ -34,8 +34,8 @@ struct BoolMatrix {
 
 template <auto bool_matrix>
 constexpr auto makeSparseEntriesFromBoolMatrix() {
-  constexpr auto num_rows = std::size_t{bool_matrix.num_rows};
-  constexpr auto num_cols = std::size_t{bool_matrix.num_cols};
+  constexpr auto num_rows = std::size_t{bool_matrix.numRows()};
+  constexpr auto num_cols = std::size_t{bool_matrix.numCols()};
   constexpr auto nnz = bool_matrix.nnz();
 
   std::array<Entry, nnz> entries;

--- a/ctldl/sparsity/get_contributions.hpp
+++ b/ctldl/sparsity/get_contributions.hpp
@@ -20,16 +20,16 @@ constexpr void foreachContributingEntry(const Sparsity& sparsity,
                                         const std::size_t j,
                                         const std::size_t column_limit,
                                         TernaryFunction f) {
-  const auto row_begin_i = sparsity_below.row_begin_indices[i];
-  const auto row_end_i = sparsity_below.row_begin_indices[i + 1];
-  const auto row_begin_j = sparsity.row_begin_indices[j];
-  const auto row_end_j = sparsity.row_begin_indices[j + 1];
+  const auto row_begin_i = sparsity_below.rowBeginIndices()[i];
+  const auto row_end_i = sparsity_below.rowBeginIndices()[i + 1];
+  const auto row_begin_j = sparsity.rowBeginIndices()[j];
+  const auto row_end_j = sparsity.rowBeginIndices()[j + 1];
 
   auto entry_index_ik = row_begin_i;
   auto entry_index_jk = row_begin_j;
   while (entry_index_ik != row_end_i && entry_index_jk != row_end_j) {
-    const auto col_index_i = sparsity_below.entries[entry_index_ik].col_index;
-    const auto col_index_j = sparsity.entries[entry_index_jk].col_index;
+    const auto col_index_i = sparsity_below.entries()[entry_index_ik].col_index;
+    const auto col_index_j = sparsity.entries()[entry_index_jk].col_index;
     if (col_index_i >= column_limit || col_index_j >= column_limit) {
       break;
     }
@@ -59,8 +59,8 @@ constexpr auto getNumContributionsMixed(const Sparsity& sparsity,
 }
 
 template <auto sparsity, auto sparsity_below, std::size_t i, std::size_t j,
-          std::size_t column_limit = std::min(sparsity.num_cols,
-                                              sparsity_below.num_cols)>
+          std::size_t column_limit = std::min(sparsity.numCols(),
+                                              sparsity_below.numCols())>
 constexpr auto getContributionsMixed() {
   constexpr auto num_contrib =
       getNumContributionsMixed(sparsity, sparsity_below, i, j, column_limit);

--- a/ctldl/sparsity/get_entries_csr.hpp
+++ b/ctldl/sparsity/get_entries_csr.hpp
@@ -11,10 +11,10 @@ namespace ctldl {
 
 template <class Sparsity>
 constexpr auto getRowCounts(const Sparsity& sparsity) {
-  std::array<std::size_t, Sparsity::num_rows> row_counts;
+  std::array<std::size_t, Sparsity::numRows()> row_counts;
   fixInitIfZeroLengthArray(row_counts);
   row_counts.fill(0);
-  for (const auto entry : sparsity.entries) {
+  for (const auto entry : sparsity.entries()) {
     row_counts[entry.row_index] += 1;
   }
   return row_counts;
@@ -35,10 +35,10 @@ constexpr auto getEntriesCSR(const Sparsity& sparsity) {
   const auto row_counts = getRowCounts(sparsity);
   const auto row_begin_indices = getRowBeginIndices(row_counts);
 
-  std::array<Entry, Sparsity::nnz> entries;
+  std::array<Entry, Sparsity::nnz()> entries;
   fixInitIfZeroLengthArray(entries);
   auto row_insert_indices = row_begin_indices;
-  for (const auto entry : sparsity.entries) {
+  for (const auto entry : sparsity.entries()) {
     entries[row_insert_indices[entry.row_index]] =
         Entry{entry.row_index, entry.col_index};
     row_insert_indices[entry.row_index] += 1;

--- a/ctldl/sparsity/get_influenced.hpp
+++ b/ctldl/sparsity/get_influenced.hpp
@@ -51,7 +51,7 @@ struct Influenced {
  */
 template <std::size_t i, std::size_t j, auto sparsity_source,
           auto sparsity_target,
-          std::size_t target_column_limit = sparsity_target.num_cols>
+          std::size_t target_column_limit = sparsity_target.numCols()>
 constexpr auto getInfluencedList() {
   constexpr auto num_influenced =
       getNumInfluenced(sparsity_source, j, target_column_limit);

--- a/ctldl/sparsity/get_matrix_value_at.hpp
+++ b/ctldl/sparsity/get_matrix_value_at.hpp
@@ -5,21 +5,32 @@
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
+#include <optional>
 
 
 namespace ctldl {
+
+template <class Sparsity>
+constexpr std::optional<std::size_t> findEntryIndex(const Sparsity& sparsity,
+                                                    const Entry entry) {
+  const auto& entries = sparsity.entries();
+  const auto entries_begin = std::cbegin(entries);
+  const auto entries_end = std::cend(entries);
+  const auto it = std::find(entries_begin, entries_end, entry);
+  if (it == entries_end) {
+    return std::nullopt;
+  }
+  return static_cast<std::size_t>(it - entries_begin);
+}
 
 template <std::size_t i, std::size_t j, class Matrix>
 constexpr auto getMatrixValueAt(const Matrix& matrix) {
   using Value = decltype(matrix.valueAt(0));
 
-  constexpr auto entries_begin = std::cbegin(Matrix::sparsity.entries);
-  constexpr auto entries_end = std::cend(Matrix::sparsity.entries);
-
-  constexpr auto it = std::find(entries_begin, entries_end, Entry{i, j});
-  if constexpr (it != entries_end) {
-    constexpr auto entry_index = std::size_t{it - entries_begin};
-    return matrix.valueAt(entry_index);
+  constexpr std::optional<std::size_t> entry_index =
+      findEntryIndex(Matrix::sparsity, Entry{i, j});
+  if constexpr (entry_index.has_value()) {
+    return matrix.valueAt(entry_index.value());
   }
   return Value{0.0};
 }

--- a/ctldl/sparsity/is_lower_triangle.hpp
+++ b/ctldl/sparsity/is_lower_triangle.hpp
@@ -4,7 +4,7 @@ namespace ctldl {
 
 template <class Sparsity>
 constexpr bool isLowerTriangle(const Sparsity& sparsity) {
-  for (const auto& entry : sparsity.entries) {
+  for (const auto& entry : sparsity.entries()) {
     if (entry.row_index <= entry.col_index) {
       return false;
     }

--- a/ctldl/sparsity/is_sparsity_subset.hpp
+++ b/ctldl/sparsity/is_sparsity_subset.hpp
@@ -13,16 +13,16 @@ namespace ctldl {
 template <class SparsityLhs, class SparsityRhs>
 constexpr bool isSparsitySubset(
     const SparsityLhs& sparsity_lhs_in, const SparsityRhs& sparsity_rhs_in,
-    const Permutation<SparsityLhs::num_rows>& permutation_row = {},
-    const Permutation<SparsityLhs::num_cols>& permutation_col = {}) {
+    const Permutation<SparsityLhs::numRows()>& permutation_row = {},
+    const Permutation<SparsityLhs::numCols()>& permutation_col = {}) {
   const auto sparsity_lhs = makeSparsityCSR(
       getSparsityPermuted(sparsity_lhs_in, permutation_row, permutation_col));
   const auto sparsity_rhs = makeSparsityCSR(sparsity_rhs_in);
 
-  static_assert(sparsity_lhs.num_rows == sparsity_rhs.num_rows);
-  static_assert(sparsity_lhs.num_cols == sparsity_rhs.num_cols);
-  constexpr auto num_rows = std::size_t{sparsity_lhs.num_rows};
-  constexpr auto num_cols = std::size_t{sparsity_lhs.num_cols};
+  static_assert(sparsity_lhs.numRows() == sparsity_rhs.numRows());
+  static_assert(sparsity_lhs.numCols() == sparsity_rhs.numCols());
+  constexpr auto num_rows = std::size_t{sparsity_lhs.numRows()};
+  constexpr auto num_cols = std::size_t{sparsity_lhs.numCols()};
 
   std::array<bool, num_cols> is_nonzero_rhs;
   fixInitIfZeroLengthArray(is_nonzero_rhs);

--- a/ctldl/sparsity/is_square.hpp
+++ b/ctldl/sparsity/is_square.hpp
@@ -4,7 +4,7 @@ namespace ctldl {
 
 template <class Sparsity>
 constexpr bool isSquare() {
-  return Sparsity::num_rows == Sparsity::num_cols;
+  return Sparsity::numRows() == Sparsity::numCols();
 }
 
 template <class Sparsity>

--- a/ctldl/sparsity/sparsity_csr.hpp
+++ b/ctldl/sparsity/sparsity_csr.hpp
@@ -18,18 +18,22 @@ struct SparsityCSR : public Sparsity<nnz, num_rows, num_cols> {
   constexpr explicit SparsityCSR(
       std::pair<std::array<Entry, nnz>, std::array<std::size_t, num_rows + 1>>
           helper)
-      : Base(helper.first), row_begin_indices(helper.second) {}
+      : Base(helper.first), m_row_begin_indices(helper.second) {}
 
  public:
-  std::array<std::size_t, num_rows + 1> row_begin_indices;
+  std::array<std::size_t, num_rows + 1> m_row_begin_indices;
+  constexpr const std::array<std::size_t, num_rows + 1>& rowBeginIndices()
+      const {
+    return m_row_begin_indices;
+  }
 
   template <class SparsityIn>
   constexpr explicit SparsityCSR(const SparsityIn& sparsity)
       : SparsityCSR(getEntriesCSR(sparsity)) {}
 
   constexpr auto rowView(const std::size_t i) const {
-    return std::span{Base::entries.data() + row_begin_indices[i],
-                     Base::entries.data() + row_begin_indices[i + 1]};
+    return std::span{Base::entries().data() + rowBeginIndices()[i],
+                     Base::entries().data() + rowBeginIndices()[i + 1]};
   }
 
   constexpr auto find(const std::size_t i, const std::size_t j) const {
@@ -50,7 +54,8 @@ struct SparsityCSR : public Sparsity<nnz, num_rows, num_cols> {
 
 template <class SparsityIn>
 SparsityCSR(const SparsityIn&)
-    -> SparsityCSR<SparsityIn::nnz, SparsityIn::num_rows, SparsityIn::num_cols>;
+    -> SparsityCSR<SparsityIn::nnz(), SparsityIn::numRows(),
+                   SparsityIn::numCols()>;
 
 template <class SparsityIn>
 constexpr auto makeSparsityCSR(const SparsityIn& sparsity) {

--- a/ctldl/sparsity/sparsity_lower_triangle.hpp
+++ b/ctldl/sparsity/sparsity_lower_triangle.hpp
@@ -15,7 +15,7 @@ template <class Sparsity>
 constexpr auto getNnzLowerTriangle(const Sparsity& sparsity) {
   static_assert(isSquare<Sparsity>());
   std::size_t nnz = 0;
-  for (const auto entry : sparsity.entries) {
+  for (const auto entry : sparsity.entries()) {
     nnz += (entry.row_index > entry.col_index);
   }
   return nnz;
@@ -30,7 +30,7 @@ constexpr auto getEntriesLowerTriangle(const Sparsity& sparsity,
   std::array<Entry, nnz> entries;
   fixInitIfZeroLengthArray(entries);
   std::size_t entry_index = 0;
-  for (const auto entry : sparsity.entries) {
+  for (const auto entry : sparsity.entries()) {
     if (entry.row_index <= entry.col_index) {
       continue;
     }
@@ -44,7 +44,7 @@ constexpr auto getEntriesLowerTriangle(const Sparsity& sparsity,
 template <auto sparsity, class PermutationIn>
 constexpr auto getSparsityLowerTriangle(const PermutationIn& permutation) {
   static_assert(isSquare(sparsity));
-  constexpr auto dim = std::size_t{sparsity.num_rows};
+  constexpr auto dim = std::size_t{sparsity.numRows()};
   constexpr auto nnz = getNnzLowerTriangle(sparsity);
   const auto entries = getEntriesLowerTriangle<nnz>(sparsity, permutation);
   return Sparsity<nnz, dim, dim>(entries);

--- a/ctldl/sparsity/sparsity_permuted.hpp
+++ b/ctldl/sparsity/sparsity_permuted.hpp
@@ -15,20 +15,20 @@ constexpr auto getSparsityPermuted(const SparsityIn& sparsity,
                                    const PermutationRow& permutation_row,
                                    const PermutationCol& permutation_col) {
   using std::size;
-  constexpr auto nnz = std::size_t{size(decltype(sparsity.entries){})};
+  constexpr auto nnz = std::size_t{size(decltype(sparsity.entries()){})};
 
   const auto inverse_permutation_row = invertPermutation(permutation_row);
   const auto inverse_permutation_col = invertPermutation(permutation_col);
 
   std::array<Entry, nnz> entries;
   std::size_t entry_index = 0;
-  for (const auto entry : sparsity.entries) {
+  for (const auto entry : sparsity.entries()) {
     entries[entry_index] = permutedEntry(entry, inverse_permutation_row,
                                          inverse_permutation_col);
     entry_index += 1;
   }
 
-  return Sparsity<nnz, SparsityIn::num_rows, SparsityIn::num_cols>(entries);
+  return Sparsity<nnz, SparsityIn::numRows(), SparsityIn::numCols()>(entries);
 }
 
 }  // namespace ctldl

--- a/ctldl/symbolic/add_row_elimination_tree.hpp
+++ b/ctldl/symbolic/add_row_elimination_tree.hpp
@@ -14,7 +14,7 @@ constexpr void addRowEliminationTree(const Sparsity& sparsity,
                                      std::array<std::size_t, dim>& ancestors,
                                      const std::size_t row_offset = 0,
                                      const std::size_t col_offset = 0) {
-  static_assert(dim >= Sparsity::num_rows);
+  static_assert(dim >= Sparsity::numRows());
 
   const auto i = row_index + row_offset;
   for (const auto entry : sparsity.rowView(row_index)) {

--- a/ctldl/symbolic/compute_elimination_tree.hpp
+++ b/ctldl/symbolic/compute_elimination_tree.hpp
@@ -13,7 +13,7 @@ namespace ctldl {
 template <class Sparsity>
 constexpr auto computeEliminationTree(const Sparsity& sparsity) {
   static_assert(isSquare<Sparsity>());
-  constexpr auto dim = Sparsity::num_rows;
+  constexpr auto dim = Sparsity::numRows();
 
   EliminationTree<dim> tree;
   std::array<std::size_t, dim> ancestors;

--- a/ctldl/symbolic/compute_elimination_tree_blocked.hpp
+++ b/ctldl/symbolic/compute_elimination_tree_blocked.hpp
@@ -23,33 +23,33 @@ constexpr auto computeEliminationTreeBlocked3x3(const Sparsity11& sparsity11,
   static_assert(isSquare<Sparsity11>());
   static_assert(isSquare<Sparsity22>());
   static_assert(isSquare<Sparsity33>());
-  static_assert(Sparsity21::num_cols == Sparsity11::num_cols);
-  static_assert(Sparsity21::num_rows == Sparsity22::num_rows);
-  static_assert(Sparsity31::num_cols == Sparsity11::num_cols);
-  static_assert(Sparsity32::num_cols == Sparsity22::num_cols);
-  static_assert(Sparsity31::num_rows == Sparsity33::num_rows);
-  static_assert(Sparsity32::num_rows == Sparsity33::num_rows);
+  static_assert(Sparsity21::numCols() == Sparsity11::numCols());
+  static_assert(Sparsity21::numRows() == Sparsity22::numRows());
+  static_assert(Sparsity31::numCols() == Sparsity11::numCols());
+  static_assert(Sparsity32::numCols() == Sparsity22::numCols());
+  static_assert(Sparsity31::numRows() == Sparsity33::numRows());
+  static_assert(Sparsity32::numRows() == Sparsity33::numRows());
   constexpr auto num_rows =
-      Sparsity11::num_rows + Sparsity22::num_rows + Sparsity33::num_rows;
+      Sparsity11::numRows() + Sparsity22::numRows() + Sparsity33::numRows();
   EliminationTree<num_rows> tree;
 
   std::array<std::size_t, num_rows> ancestors;
   std::iota(ancestors.begin(), ancestors.end(), 0);
 
-  for (std::size_t i = 0; i < Sparsity11::num_rows; ++i) {
+  for (std::size_t i = 0; i < Sparsity11::numRows(); ++i) {
     addRowEliminationTree(sparsity11, i, tree, ancestors);
   }
-  for (std::size_t i = 0; i < Sparsity21::num_rows; ++i) {
-    constexpr auto row_offset = Sparsity11::num_rows;
-    constexpr auto col_offset = Sparsity21::num_cols;
+  for (std::size_t i = 0; i < Sparsity21::numRows(); ++i) {
+    constexpr auto row_offset = Sparsity11::numRows();
+    constexpr auto col_offset = Sparsity21::numCols();
     addRowEliminationTree(sparsity21, i, tree, ancestors, row_offset);
     addRowEliminationTree(sparsity22, i, tree, ancestors, row_offset,
                           col_offset);
   }
-  for (std::size_t i = 0; i < Sparsity31::num_rows; ++i) {
-    constexpr auto row_offset = Sparsity11::num_rows + Sparsity22::num_rows;
-    constexpr auto col_offset2 = Sparsity11::num_cols;
-    constexpr auto col_offset3 = Sparsity11::num_cols + Sparsity22::num_cols;
+  for (std::size_t i = 0; i < Sparsity31::numRows(); ++i) {
+    constexpr auto row_offset = Sparsity11::numRows() + Sparsity22::numRows();
+    constexpr auto col_offset2 = Sparsity11::numCols();
+    constexpr auto col_offset3 = Sparsity11::numCols() + Sparsity22::numCols();
     addRowEliminationTree(sparsity31, i, tree, ancestors, row_offset);
     addRowEliminationTree(sparsity32, i, tree, ancestors, row_offset,
                           col_offset2);
@@ -65,8 +65,8 @@ constexpr auto computeEliminationTreeBlocked(const Sparsity11& sparsity11,
                                              const Sparsity22& sparsity22) {
   return computeEliminationTreeBlocked3x3(
       sparsity11, sparsity21, sparsity22,
-      makeEmptySparsityCSR<0, Sparsity11::num_cols>(),
-      makeEmptySparsityCSR<0, Sparsity22::num_cols>(),
+      makeEmptySparsityCSR<0, Sparsity11::numCols()>(),
+      makeEmptySparsityCSR<0, Sparsity22::numCols()>(),
       makeEmptySparsityCSR<0, 0>());
 }
 

--- a/ctldl/symbolic/compute_elimination_tree_repeating.hpp
+++ b/ctldl/symbolic/compute_elimination_tree_repeating.hpp
@@ -19,8 +19,8 @@ constexpr auto computeEliminationTreeRepeating(const SparsityA& sparsity_A,
                                                const SparsityB& sparsity_B) {
   static_assert(isSquare<SparsityA>());
   static_assert(isSquare<SparsityB>());
-  static_assert(SparsityA::num_rows == SparsityB::num_rows);
-  constexpr auto dim = SparsityA::num_rows;
+  static_assert(SparsityA::numRows() == SparsityB::numRows());
+  constexpr auto dim = SparsityA::numRows();
 
   EliminationTree<2 * dim> tree;
   EliminationTree<dim> tree_init;

--- a/ctldl/symbolic/filled_in_sparsity.hpp
+++ b/ctldl/symbolic/filled_in_sparsity.hpp
@@ -10,10 +10,10 @@
 
 namespace ctldl {
 
-template <auto sparsity, auto permutation = Permutation<sparsity.num_rows>{}>
+template <auto sparsity, auto permutation = Permutation<sparsity.numRows()>{}>
 constexpr auto getFilledInSparsity() {
   static_assert(isSquare(sparsity));
-  constexpr auto dim = std::size_t{sparsity.num_rows};
+  constexpr auto dim = std::size_t{sparsity.numRows()};
   return makeSparsity<dim, dim>(
       getEntriesWithFill<SparsityCSR(
           getSparsityLowerTriangle<sparsity>(permutation))>());

--- a/ctldl/symbolic/filled_in_sparsity_blocked.hpp
+++ b/ctldl/symbolic/filled_in_sparsity_blocked.hpp
@@ -27,16 +27,16 @@ constexpr auto getFilledInNumNonZerosBlocked3x3(const Sparsity11& sparsity11,
   LowerTriangleBlocked3x3 nnz{std::size_t{0}, std::size_t{0}, std::size_t{0},
                               std::size_t{0}, std::size_t{0}, std::size_t{0}};
   const auto count_nonzero = [&](const std::size_t i, const std::size_t j) {
-    if (j < sparsity11.num_cols) {
-      if (i < sparsity11.num_rows) {
+    if (j < sparsity11.numCols()) {
+      if (i < sparsity11.numRows()) {
         nnz.block11 += 1;
-      } else if (i < sparsity11.num_rows + sparsity22.num_rows) {
+      } else if (i < sparsity11.numRows() + sparsity22.numRows()) {
         nnz.block21 += 1;
       } else {
         nnz.block31 += 1;
       }
-    } else if (j < sparsity11.num_cols + sparsity22.num_cols) {
-      if (i < sparsity11.num_rows + sparsity22.num_rows) {
+    } else if (j < sparsity11.numCols() + sparsity22.numCols()) {
+      if (i < sparsity11.numRows() + sparsity22.numRows()) {
         nnz.block22 += 1;
       } else {
         nnz.block32 += 1;
@@ -56,9 +56,9 @@ constexpr auto getFilledInNumNonZerosBlocked(const Sparsity11& sparsity11,
                                              const Sparsity21& sparsity21,
                                              const Sparsity22& sparsity22) {
   constexpr auto sparsity31_dummy =
-      makeEmptySparsityCSR<0, Sparsity11::num_cols>();
+      makeEmptySparsityCSR<0, Sparsity11::numCols()>();
   constexpr auto sparsity32_dummy =
-      makeEmptySparsityCSR<0, Sparsity22::num_cols>();
+      makeEmptySparsityCSR<0, Sparsity22::numCols()>();
   constexpr auto sparsity33_dummy = makeEmptySparsityCSR<0, 0>();
   const auto nnz = getFilledInNumNonZerosBlocked3x3(
       sparsity11, sparsity21, sparsity22, sparsity31_dummy, sparsity32_dummy,
@@ -68,14 +68,14 @@ constexpr auto getFilledInNumNonZerosBlocked(const Sparsity11& sparsity11,
 
 template <auto sparsity11_in, auto sparsity21_in, auto sparsity22_in,
           auto sparsity31_in, auto sparsity32_in, auto sparsity33_in,
-          auto permutation1 = Permutation<sparsity11_in.num_rows>(),
-          auto permutation2 = Permutation<sparsity22_in.num_rows>(),
-          auto permutation3 = Permutation<sparsity33_in.num_rows>()>
+          auto permutation1 = Permutation<sparsity11_in.numRows()>(),
+          auto permutation2 = Permutation<sparsity22_in.numRows()>(),
+          auto permutation3 = Permutation<sparsity33_in.numRows()>()>
 constexpr auto getFilledInSparsityBlocked3x3() {
   static_assert(isSquare(sparsity11_in));
   static_assert(isSquare(sparsity22_in));
-  static_assert(sparsity21_in.num_cols == sparsity11_in.num_cols);
-  static_assert(sparsity22_in.num_rows == sparsity21_in.num_rows);
+  static_assert(sparsity21_in.numCols() == sparsity11_in.numCols());
+  static_assert(sparsity22_in.numRows() == sparsity21_in.numRows());
 
   constexpr auto sparsity11 =
       SparsityCSR(getSparsityLowerTriangle<sparsity11_in>(permutation1));
@@ -103,33 +103,33 @@ constexpr auto getFilledInSparsityBlocked3x3() {
                                       std::size_t{0}, std::size_t{0},
                                       std::size_t{0}, std::size_t{0}};
   const auto add_nonzero = [&](const std::size_t i, const std::size_t j) {
-    if (j < sparsity11.num_cols) {
-      if (i < sparsity11.num_rows) {
+    if (j < sparsity11.numCols()) {
+      if (i < sparsity11.numRows()) {
         entries11[entry_index.block11] = Entry{i, j};
         entry_index.block11 += 1;
-      } else if (i < sparsity11.num_rows + sparsity22.num_rows) {
-        entries21[entry_index.block21] = Entry{i - sparsity11.num_rows, j};
+      } else if (i < sparsity11.numRows() + sparsity22.numRows()) {
+        entries21[entry_index.block21] = Entry{i - sparsity11.numRows(), j};
         entry_index.block21 += 1;
       } else {
         entries31[entry_index.block31] =
-            Entry{i - sparsity11.num_rows - sparsity22.num_rows, j};
+            Entry{i - sparsity11.numRows() - sparsity22.numRows(), j};
         entry_index.block31 += 1;
       }
-    } else if (j < sparsity11.num_cols + sparsity22.num_cols) {
-      if (i < sparsity11.num_rows + sparsity22.num_rows) {
+    } else if (j < sparsity11.numCols() + sparsity22.numCols()) {
+      if (i < sparsity11.numRows() + sparsity22.numRows()) {
         entries22[entry_index.block22] =
-            Entry{i - sparsity11.num_rows, j - sparsity11.num_cols};
+            Entry{i - sparsity11.numRows(), j - sparsity11.numCols()};
         entry_index.block22 += 1;
       } else {
         entries32[entry_index.block32] =
-            Entry{i - sparsity11.num_rows - sparsity22.num_rows,
-                  j - sparsity11.num_cols};
+            Entry{i - sparsity11.numRows() - sparsity22.numRows(),
+                  j - sparsity11.numCols()};
         entry_index.block32 += 1;
       }
     } else {
       entries33[entry_index.block33] =
-          Entry{i - sparsity11.num_rows - sparsity22.num_rows,
-                j - sparsity11.num_cols - sparsity22.num_cols};
+          Entry{i - sparsity11.numRows() - sparsity22.numRows(),
+                j - sparsity11.numCols() - sparsity22.numCols()};
       entry_index.block33 += 1;
     }
   };
@@ -146,20 +146,20 @@ constexpr auto getFilledInSparsityBlocked3x3() {
   sortEntriesRowMajorSorted(entries33);
 
   return LowerTriangleBlocked3x3{
-      makeSparsity<sparsity11.num_rows, sparsity11.num_cols>(entries11),
-      makeSparsity<sparsity21.num_rows, sparsity21.num_cols>(entries21),
-      makeSparsity<sparsity22.num_rows, sparsity22.num_cols>(entries22),
-      makeSparsity<sparsity31.num_rows, sparsity31.num_cols>(entries31),
-      makeSparsity<sparsity32.num_rows, sparsity32.num_cols>(entries32),
-      makeSparsity<sparsity33.num_rows, sparsity33.num_cols>(entries33)};
+      makeSparsity<sparsity11.numRows(), sparsity11.numCols()>(entries11),
+      makeSparsity<sparsity21.numRows(), sparsity21.numCols()>(entries21),
+      makeSparsity<sparsity22.numRows(), sparsity22.numCols()>(entries22),
+      makeSparsity<sparsity31.numRows(), sparsity31.numCols()>(entries31),
+      makeSparsity<sparsity32.numRows(), sparsity32.numCols()>(entries32),
+      makeSparsity<sparsity33.numRows(), sparsity33.numCols()>(entries33)};
 }
 
 template <auto sparsity11, auto sparsity21, auto sparsity22,
-          auto permutation1 = Permutation<sparsity11.num_rows>(),
-          auto permutation2 = Permutation<sparsity22.num_rows>()>
+          auto permutation1 = Permutation<sparsity11.numRows()>(),
+          auto permutation2 = Permutation<sparsity22.numRows()>()>
 constexpr auto getFilledInSparsityBlocked() {
-  constexpr auto sparsity31_dummy = makeEmptySparsity<0, sparsity11.num_cols>();
-  constexpr auto sparsity32_dummy = makeEmptySparsity<0, sparsity22.num_cols>();
+  constexpr auto sparsity31_dummy = makeEmptySparsity<0, sparsity11.numCols()>();
+  constexpr auto sparsity32_dummy = makeEmptySparsity<0, sparsity22.numCols()>();
   constexpr auto sparsity33_dummy = makeEmptySparsity<0, 0>();
   constexpr auto permutation3_dummy = Permutation<0>{};
   const auto sparsity = getFilledInSparsityBlocked3x3<

--- a/ctldl/symbolic/filled_in_sparsity_repeating.hpp
+++ b/ctldl/symbolic/filled_in_sparsity_repeating.hpp
@@ -13,8 +13,8 @@ template <auto sparsity_in_A, auto sparsity_in_B, auto permutation>
 constexpr auto getFilledInSparsityRepeating() {
   static_assert(isSquare(sparsity_in_A));
   static_assert(isSquare(sparsity_in_B));
-  static_assert(sparsity_in_B.num_rows == sparsity_in_A.num_rows);
-  constexpr auto dim = std::size_t{sparsity_in_A.num_rows};
+  static_assert(sparsity_in_B.numRows() == sparsity_in_A.numRows());
+  constexpr auto dim = std::size_t{sparsity_in_A.numRows()};
 
   const auto sparsity_filled =
       getFilledInSparsityRepeatingArrowhead<sparsity_in_A, sparsity_in_B,

--- a/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.hpp
+++ b/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.hpp
@@ -21,9 +21,9 @@ constexpr auto getNumNonZerosWithFillRepeatingArrowhead(
     const SparsityOuter& sparsity_C) {
   static_assert(isSquare<SparsityDiag>());
   static_assert(isSquare<SparsitySubdiag>());
-  static_assert(SparsityDiag::num_rows == SparsitySubdiag::num_rows);
-  constexpr auto dim = std::size_t{SparsityDiag::num_rows};
-  static_assert(SparsityOuter::num_cols == SparsityDiag::num_cols);
+  static_assert(SparsityDiag::numRows() == SparsitySubdiag::numRows());
+  constexpr auto dim = std::size_t{SparsityDiag::numRows()};
+  static_assert(SparsityOuter::numCols() == SparsityDiag::numCols());
 
   RepeatingBlockTridiagonalArrowhead nnz{std::size_t{0}, std::size_t{0},
                                          std::size_t{0}};
@@ -48,10 +48,10 @@ template <auto sparsity_in_A, auto sparsity_in_B, auto sparsity_in_C,
 constexpr auto getFilledInSparsityRepeatingArrowhead() {
   static_assert(isSquare(sparsity_in_A));
   static_assert(isSquare(sparsity_in_B));
-  static_assert(sparsity_in_B.num_rows == sparsity_in_A.num_rows);
-  static_assert(sparsity_in_C.num_cols == sparsity_in_A.num_cols);
-  constexpr auto dim = std::size_t{sparsity_in_A.num_rows};
-  constexpr auto dim_outer = std::size_t{sparsity_in_C.num_rows};
+  static_assert(sparsity_in_B.numRows() == sparsity_in_A.numRows());
+  static_assert(sparsity_in_C.numCols() == sparsity_in_A.numCols());
+  constexpr auto dim = std::size_t{sparsity_in_A.numRows()};
+  constexpr auto dim_outer = std::size_t{sparsity_in_C.numRows()};
 
   constexpr auto sparsity_A =
       SparsityCSR(getSparsityLowerTriangle<sparsity_in_A>(permutation));

--- a/ctldl/symbolic/foreach_nonzero_with_fill.hpp
+++ b/ctldl/symbolic/foreach_nonzero_with_fill.hpp
@@ -14,7 +14,7 @@ template <class Sparsity, class UnaryFunction>
 constexpr void foreachNonZeroWithFill(const Sparsity& sparsity,
                                       UnaryFunction f) {
   static_assert(isSquare<Sparsity>());
-  constexpr auto dim = Sparsity::num_rows;
+  constexpr auto dim = Sparsity::numRows();
 
   const auto tree = computeEliminationTree(sparsity);
   std::array<std::size_t, dim> visitor;

--- a/ctldl/symbolic/foreach_nonzero_with_fill_blocked.hpp
+++ b/ctldl/symbolic/foreach_nonzero_with_fill_blocked.hpp
@@ -23,30 +23,30 @@ constexpr void foreachNonZeroWithFillBlocked3x3(const Sparsity11& sparsity11,
                                                 UnaryFunction f) {
   static_assert(isSquare<Sparsity11>());
   static_assert(isSquare<Sparsity22>());
-  static_assert(Sparsity21::num_cols == Sparsity11::num_cols);
-  static_assert(Sparsity22::num_rows == Sparsity21::num_rows);
+  static_assert(Sparsity21::numCols() == Sparsity11::numCols());
+  static_assert(Sparsity22::numRows() == Sparsity21::numRows());
   constexpr auto num_rows =
-      Sparsity11::num_rows + Sparsity22::num_rows + Sparsity33::num_rows;
+      Sparsity11::numRows() + Sparsity22::numRows() + Sparsity33::numRows();
 
   const auto tree = computeEliminationTreeBlocked3x3(
       sparsity11, sparsity21, sparsity22, sparsity31, sparsity32, sparsity33);
   std::array<std::size_t, num_rows> visitor;
   std::iota(visitor.begin(), visitor.end(), 0);
-  for (std::size_t i = 0; i < Sparsity11::num_rows; ++i) {
+  for (std::size_t i = 0; i < Sparsity11::numRows(); ++i) {
     foreachAncestorInSubtree(sparsity11, tree, i, visitor, f);
   }
-  for (std::size_t i = 0; i < Sparsity21::num_rows; ++i) {
-    constexpr auto row_offset = Sparsity11::num_rows;
-    constexpr auto col_offset = Sparsity21::num_cols;
+  for (std::size_t i = 0; i < Sparsity21::numRows(); ++i) {
+    constexpr auto row_offset = Sparsity11::numRows();
+    constexpr auto col_offset = Sparsity21::numCols();
     foreachAncestorInSubtree(sparsity21, tree, i, visitor, f,
                              row_offset);
     foreachAncestorInSubtree(sparsity22, tree, i, visitor, f,
                              row_offset, col_offset);
   }
-  for (std::size_t i = 0; i < Sparsity31::num_rows; ++i) {
-    constexpr auto row_offset = Sparsity11::num_rows + Sparsity22::num_rows;
-    constexpr auto col_offset2 = Sparsity11::num_cols;
-    constexpr auto col_offset3 = Sparsity11::num_cols + Sparsity22::num_cols;
+  for (std::size_t i = 0; i < Sparsity31::numRows(); ++i) {
+    constexpr auto row_offset = Sparsity11::numRows() + Sparsity22::numRows();
+    constexpr auto col_offset2 = Sparsity11::numCols();
+    constexpr auto col_offset3 = Sparsity11::numCols() + Sparsity22::numCols();
     foreachAncestorInSubtree(sparsity31, tree, i, visitor, f,
                              row_offset);
     foreachAncestorInSubtree(sparsity32, tree, i, visitor, f,
@@ -64,8 +64,8 @@ constexpr void foreachNonZeroWithFillBlocked(const Sparsity11& sparsity11,
                                              UnaryFunction f) {
   foreachNonZeroWithFillBlocked3x3(
       sparsity11, sparsity21, sparsity22,
-      makeEmptySparsityCSR<0, Sparsity11::num_cols>(),
-      makeEmptySparsityCSR<0, Sparsity22::num_cols>(),
+      makeEmptySparsityCSR<0, Sparsity11::numCols()>(),
+      makeEmptySparsityCSR<0, Sparsity22::numCols()>(),
       makeEmptySparsityCSR<0, 0>(), f);
 }
 

--- a/ctldl/symbolic/foreach_nonzero_with_fill_repeating_arrowhead.hpp
+++ b/ctldl/symbolic/foreach_nonzero_with_fill_repeating_arrowhead.hpp
@@ -44,10 +44,10 @@ constexpr void foreachNonZeroWithFillRepeatingArrowhead(
     const SparsityOuter& sparsity_outer, UnaryFunction f) {
   static_assert(isSquare<SparsityDiag>());
   static_assert(isSquare<SparsitySubdiag>());
-  static_assert(SparsitySubdiag::num_rows == SparsityDiag::num_rows);
-  static_assert(SparsityOuter::num_cols == SparsityDiag::num_cols);
-  constexpr auto dim = std::size_t{SparsityDiag::num_rows};
-  constexpr auto dim_outer = std::size_t{SparsityOuter::num_rows};
+  static_assert(SparsitySubdiag::numRows() == SparsityDiag::numRows());
+  static_assert(SparsityOuter::numCols() == SparsityDiag::numCols());
+  constexpr auto dim = std::size_t{SparsityDiag::numRows()};
+  constexpr auto dim_outer = std::size_t{SparsityOuter::numRows()};
 
   const auto tree =
       computeEliminationTreeRepeating(sparsity_diag, sparsity_subdiag);

--- a/ctldl/symbolic/is_chordal_blocked.hpp
+++ b/ctldl/symbolic/is_chordal_blocked.hpp
@@ -13,16 +13,16 @@ constexpr bool isChordalBlocked(const Sparsity11& sparsity11,
                                 const Sparsity22& sparsity22) {
   static_assert(isSquare<Sparsity11>());
   static_assert(isSquare<Sparsity22>());
-  static_assert(Sparsity21::num_cols == Sparsity11::num_cols);
-  static_assert(Sparsity22::num_rows == Sparsity21::num_rows);
+  static_assert(Sparsity21::numCols() == Sparsity11::numCols());
+  static_assert(Sparsity22::numRows() == Sparsity21::numRows());
   if (!isLowerTriangle(sparsity11) || !isLowerTriangle(sparsity22)) {
     return false;
   }
   const auto nnz_filled =
       getFilledInNumNonZerosBlocked(sparsity11, sparsity21, sparsity22);
-  return nnz_filled.block11 == sparsity11.nnz &&
-         nnz_filled.block21 == sparsity21.nnz &&
-         nnz_filled.block22 == sparsity22.nnz;
+  return nnz_filled.block11 == sparsity11.nnz() &&
+         nnz_filled.block21 == sparsity21.nnz() &&
+         nnz_filled.block22 == sparsity22.nnz();
 };
 
 }  // namespace ctldl

--- a/examples/repeating/example_indef.cpp
+++ b/examples/repeating/example_indef.cpp
@@ -21,27 +21,29 @@ constexpr int dim = 2;
 
 struct MatrixA {
   struct Sparsity {
-    static constexpr int num_rows = dim;
-    static constexpr int num_cols = dim;
-    static constexpr std::array<Entry, 1> entries = {{{1, 0, 1.0}}};
+    static constexpr int numRows() { return dim; }
+    static constexpr int numCols() { return dim; }
+    static constexpr std::array<Entry, 1> entries() {
+      return {{{1, 0, 1.0}}};
+    }
   };
   static constexpr auto sparsity = Sparsity{};
 
   static constexpr double valueAt(const std::size_t i) {
-    return Sparsity::entries[i].value;
+    return Sparsity::entries()[i].value;
   }
 };
 
 struct MatrixB {
   struct Sparsity {
-    static constexpr int num_rows = dim;
-    static constexpr int num_cols = dim;
-    static constexpr std::array<Entry, 5> entries = {};
+    static constexpr int numRows() { return dim; }
+    static constexpr int numCols() { return dim; }
+    static constexpr std::array<Entry, 5> entries() { return {}; }
   };
   static constexpr auto sparsity = Sparsity{};
 
   static constexpr double valueAt(const std::size_t i) {
-    return Sparsity::entries[i].value;
+    return Sparsity::entries()[i].value;
   }
 };
 

--- a/examples/repeating/example_nos2.cpp
+++ b/examples/repeating/example_nos2.cpp
@@ -21,32 +21,35 @@ constexpr int dim = 3;
 
 struct MatrixA {
   struct Sparsity {
-    static constexpr int num_rows = dim;
-    static constexpr int num_cols = dim;
-    static constexpr std::array<Entry, 3> entries = {
-        {{0, 0, 640000.0}, {1, 1, 25600000.0}, {2, 2, 78643200000.0}}};
+    static constexpr int numRows() { return dim; }
+    static constexpr int numCols() { return dim; }
+    static constexpr std::array<Entry, 3> entries() {
+      return {{{0, 0, 640000.0}, {1, 1, 25600000.0}, {2, 2, 78643200000.0}}};
+    }
   };
   static constexpr auto sparsity = Sparsity{};
 
   static constexpr double valueAt(const std::size_t i) {
-    return Sparsity::entries[i].value;
+    return Sparsity::entries()[i].value;
   }
 };
 
 struct MatrixB {
   struct Sparsity {
-    static constexpr int num_rows = dim;
-    static constexpr int num_cols = dim;
-    static constexpr std::array<Entry, 5> entries = {{{0, 0, -320000.0},
-                                                      {1, 1, -39321600000.0},
-                                                      {1, 2, -614400000.0},
-                                                      {2, 1, 614400000.0},
-                                                      {2, 2, 6400000.0}}};
+    static constexpr int numRows() { return dim; }
+    static constexpr int numCols() { return dim; }
+    static constexpr std::array<Entry, 5> entries() {
+      return {{{0, 0, -320000.0},
+               {1, 1, -39321600000.0},
+               {1, 2, -614400000.0},
+               {2, 1, 614400000.0},
+               {2, 2, 6400000.0}}};
+    }
   };
   static constexpr auto sparsity = Sparsity{};
 
   static constexpr double valueAt(const std::size_t i) {
-    return Sparsity::entries[i].value;
+    return Sparsity::entries()[i].value;
   }
 };
 

--- a/examples/repeating/example_nos4.cpp
+++ b/examples/repeating/example_nos4.cpp
@@ -27,7 +27,7 @@ class MatrixA {
       {8, 6}, {8, 8},
       {9, 8}, {9, 9}});
 
-  static constexpr std::array<double, sparsity.nnz> values = {{
+  static constexpr std::array<double, sparsity.nnz()> values = {{
       0.17155418,
       0.035777088, 0.41788854,
       -0.1, 0.34310835,
@@ -38,7 +38,7 @@ class MatrixA {
       0.43577709,
       -0.1, 0.17155418,
       -0.035777088, 0.41788854}};
-  static constexpr std::array<double, sparsity.nnz> values_last_block = {{
+  static constexpr std::array<double, sparsity.nnz()> values_last_block = {{
       0.1,
       0.0, 0.2,
       -0.1, 0.34310835,
@@ -75,7 +75,7 @@ struct MatrixB {
       // empty row
       {9, 9}});
 
-  static constexpr std::array<double, sparsity.nnz> values = {{
+  static constexpr std::array<double, sparsity.nnz()> values = {{
       -0.2,
       -0.071554176, -0.035777088, -0.071554176, 0.035777088,
       -0.035777088, -0.017888544, -0.2, 0.035777088, -0.017888544,

--- a/examples/repeating/example_tridiagonal.cpp
+++ b/examples/repeating/example_tridiagonal.cpp
@@ -20,27 +20,27 @@ struct MatrixA {
   };
 
   struct Sparsity {
-    static constexpr int num_rows = dim;
-    static constexpr int num_cols = dim;
+    static constexpr int numRows() { return dim; }
+    static constexpr int numCols() { return dim; }
     static constexpr int nnz = dim + (dim - 1);
-    static constexpr auto entries = [] {
+    static constexpr auto entries() {
       std::array<Entry, std::size_t{nnz}> ret{};
       std::size_t entry_index = 0;
-      for (std::size_t i = 0; i < num_rows; ++i) {
+      for (std::size_t i = 0; i < numRows(); ++i) {
         ret[entry_index] = {i, i, 2.0};
         entry_index += 1;
       }
-      for (std::size_t i = 1; i < num_rows; ++i) {
+      for (std::size_t i = 1; i < numCols(); ++i) {
         ret[entry_index] = {i, i - 1, -1.0};
         entry_index += 1;
       }
       return ret;
-    }();
+    }
   };
   static constexpr auto sparsity = Sparsity{};
 
   constexpr double valueAt(const std::size_t i) const {
-    return Sparsity::entries[i].value;
+    return Sparsity::entries()[i].value;
   }
 };
 

--- a/examples/single/example_indef_single.cpp
+++ b/examples/single/example_indef_single.cpp
@@ -17,7 +17,7 @@ constexpr ctldl::Permutation<dim> permutation{{0, 1}};
 struct Matrix {
   static constexpr auto sparsity = ctldl::makeSparsity<dim, dim>({{1, 0}});
 
-  std::array<double, sparsity.nnz> values;
+  std::array<double, sparsity.nnz()> values;
   constexpr double valueAt(const std::size_t i) const {
     return values[i];
   }

--- a/examples/single/example_lfat5.cpp
+++ b/examples/single/example_lfat5.cpp
@@ -25,7 +25,7 @@ struct Matrix {
        {11, 7},  {12, 7},  {8, 8},   {11, 8},  {12, 8},  {9, 9},
        {10, 10}, {11, 11}, {13, 11}, {12, 12}, {13, 12}, {13, 13}});
 
-  std::array<double, sparsity.nnz> values;
+  std::array<double, sparsity.nnz()> values;
   constexpr double valueAt(const std::size_t i) const {
     return values[i];
   }

--- a/tests/multiply_factorize_solve_correct/repeating/test_functor.hpp
+++ b/tests/multiply_factorize_solve_correct/repeating/test_functor.hpp
@@ -32,8 +32,8 @@ struct TesterMultiplyFactorizeSolveCorrectRepeating {
 
     static_assert(isSquare(sparsity_A));
     static_assert(isSquare(sparsity_B));
-    static_assert(sparsity_B.num_rows == sparsity_A.num_rows);
-    constexpr auto block_dim = std::size_t{sparsity_A.num_rows};
+    static_assert(sparsity_B.numRows() == sparsity_A.numRows());
+    constexpr auto block_dim = std::size_t{sparsity_A.numRows()};
     constexpr Permutation<block_dim> permutation(PermutationIn::value);
 
     const auto matrices_A =

--- a/tests/multiply_factorize_solve_correct/repeating_arrowhead_linked/test_functor.hpp
+++ b/tests/multiply_factorize_solve_correct/repeating_arrowhead_linked/test_functor.hpp
@@ -42,10 +42,10 @@ struct TesterMultiplyFactorizeSolveCorrectRepeatingBlockTridiagonalArrowheadLink
   void operator()(const SolutionGenerator& solution_generator,
                   const std::size_t num_repetitions,
                   std::mt19937& value_generator) const {
-    constexpr auto dim_start = std::size_t{TestMatrixStartDiag::Matrix::sparsity.num_rows};
-    constexpr auto dim_tridiag = std::size_t{TestMatrixTridiagDiag::Matrix::sparsity.num_rows};
-    constexpr auto dim_link = std::size_t{TestMatrixLinkDiag::Matrix::sparsity.num_rows};
-    constexpr auto dim_outer = std::size_t{TestMatrixOuterDiag::Matrix::sparsity.num_rows};
+    constexpr auto dim_start = std::size_t{TestMatrixStartDiag::Matrix::sparsity.numRows()};
+    constexpr auto dim_tridiag = std::size_t{TestMatrixTridiagDiag::Matrix::sparsity.numRows()};
+    constexpr auto dim_link = std::size_t{TestMatrixLinkDiag::Matrix::sparsity.numRows()};
+    constexpr auto dim_outer = std::size_t{TestMatrixOuterDiag::Matrix::sparsity.numRows()};
 
     constexpr Permutation<dim_start> permutation_start{PermutationStart::value};
     constexpr Permutation<dim_tridiag> permutation_tridiag{PermutationTridiag::value};

--- a/tests/multiply_factorize_solve_correct/single/test_functor.hpp
+++ b/tests/multiply_factorize_solve_correct/single/test_functor.hpp
@@ -22,7 +22,7 @@ struct TesterMultiplyFactorizeSolveCorrectSingle {
   void operator()(const SolutionGenerator& solution_generator,
                   std::mt19937& value_generator) const {
     constexpr auto& sparsity = TestMatrix::Matrix::sparsity;
-    constexpr auto dim = sparsity.num_rows;
+    constexpr auto dim = sparsity.numRows();
     constexpr Permutation<dim> permutation(PermutationIn::value);
 
     auto test_matrix = generateMatrix(TestMatrix{}, value_generator);

--- a/tests/test_matrices/repeating/indef.hpp
+++ b/tests/test_matrices/repeating/indef.hpp
@@ -15,14 +15,16 @@ struct TestMatrixIndefA {
       Value value;
     };
     struct Sparsity {
-      static constexpr int num_rows = 2;
-      static constexpr int num_cols = 2;
-      static constexpr std::array<Entry, 1> entries = {{{1, 0, 1.0}}};
+      static constexpr int numRows() { return 2; }
+      static constexpr int numCols() { return 2; }
+      static constexpr std::array<Entry, 1> entries() {
+        return {{{1, 0, 1.0}}};
+      }
     };
     static constexpr auto sparsity = Sparsity{};
 
     static constexpr double valueAt(const std::size_t i) {
-      return Sparsity::entries[i].value;
+      return Sparsity::entries()[i].value;
     }
   };
 
@@ -44,14 +46,14 @@ struct TestMatrixIndefB {
       Value value;
     };
     struct Sparsity {
-      static constexpr int num_rows = 2;
-      static constexpr int num_cols = 2;
-      static constexpr std::array<Entry, 0> entries = {};
+      static constexpr int numRows() { return 2; }
+      static constexpr int numCols() { return 2; }
+      static constexpr std::array<Entry, 0> entries() { return {}; }
     };
     static constexpr auto sparsity = Sparsity{};
 
     static constexpr Value valueAt(const std::size_t i) {
-      return Sparsity::entries[i].value;
+      return Sparsity::entries()[i].value;
     }
   };
 

--- a/tests/test_matrices/repeating/nos2.hpp
+++ b/tests/test_matrices/repeating/nos2.hpp
@@ -15,15 +15,16 @@ struct TestMatrixNos2A {
       Value value;
     };
     struct Sparsity {
-      static constexpr int num_rows = 3;
-      static constexpr int num_cols = 3;
-      static constexpr std::array<Entry, 3> entries = {
-          {{0, 0, 640000.0}, {1, 1, 25600000.0}, {2, 2, 78643200000.0}}};
+      static constexpr int numRows() { return 3; }
+      static constexpr int numCols() { return 3; }
+      static constexpr std::array<Entry, 3> entries() {
+        return {{{0, 0, 640000.0}, {1, 1, 25600000.0}, {2, 2, 78643200000.0}}};
+      }
     };
     static constexpr auto sparsity = Sparsity{};
 
     static constexpr Value valueAt(const std::size_t i) {
-      return Sparsity::entries[i].value;
+      return Sparsity::entries()[i].value;
     }
   };
 
@@ -45,18 +46,20 @@ struct TestMatrixNos2B {
       Value value;
     };
     struct Sparsity {
-      static constexpr int num_rows = 3;
-      static constexpr int num_cols = 3;
-      static constexpr std::array<Entry, 5> entries = {{{0, 0, -320000.0},
-                                                        {1, 1, -39321600000.0},
-                                                        {1, 2, -614400000.0},
-                                                        {2, 1, 614400000.0},
-                                                        {2, 2, 6400000.0}}};
+      static constexpr int numRows() { return 3; }
+      static constexpr int numCols() { return 3; }
+      static constexpr std::array<Entry, 5> entries() {
+        return {{{0, 0, -320000.0},
+                 {1, 1, -39321600000.0},
+                 {1, 2, -614400000.0},
+                 {2, 1, 614400000.0},
+                 {2, 2, 6400000.0}}};
+      }
     };
     static constexpr auto sparsity = Sparsity{};
 
     static constexpr Value valueAt(const std::size_t i) {
-      return Sparsity::entries[i].value;
+      return Sparsity::entries()[i].value;
     }
   };
 

--- a/tests/test_matrices/repeating/nos4.hpp
+++ b/tests/test_matrices/repeating/nos4.hpp
@@ -27,7 +27,7 @@ struct TestMatrixNos4A {
         {8, 6}, {8, 8},
         {9, 8}, {9, 9}});
 
-    static constexpr std::array<double, sparsity.nnz> values = {{
+    static constexpr std::array<double, sparsity.nnz()> values = {{
         0.17155418,
         0.035777088, 0.41788854,
         -0.1, 0.34310835,
@@ -38,7 +38,7 @@ struct TestMatrixNos4A {
         0.43577709,
         -0.1, 0.17155418,
         -0.035777088, 0.41788854}};
-    static constexpr std::array<double, sparsity.nnz> values_last_block = {{
+    static constexpr std::array<double, sparsity.nnz()> values_last_block = {{
         0.1,
         0.0, 0.2,
         -0.1, 0.34310835,
@@ -93,7 +93,7 @@ struct TestMatrixNos4B {
         // empty row
         {9, 9}});
 
-    static constexpr std::array<double, sparsity.nnz> values = {{
+    static constexpr std::array<double, sparsity.nnz()> values = {{
         // empty row
         -0.2,
         -0.071554176, -0.035777088, -0.071554176, 0.035777088,

--- a/tests/test_matrices/repeating/tridiagonal.hpp
+++ b/tests/test_matrices/repeating/tridiagonal.hpp
@@ -22,28 +22,28 @@ struct TestMatrixTridiagonal {
     };
 
     struct Sparsity {
-      static constexpr int num_rows = block_dim;
-      static constexpr int num_cols = block_dim;
-      static constexpr int nnz = block_dim + (block_dim - 1);
-      static constexpr auto entries = [] {
-        std::array<Entry, std::size_t{nnz}> ret;
+      static constexpr int numRows() { return block_dim; }
+      static constexpr int numCols() { return block_dim; }
+      static constexpr int nnz() { return block_dim + (block_dim - 1); }
+      static constexpr auto entries() {
+        std::array<Entry, std::size_t{nnz()}> ret;
         fixInitIfZeroLengthArray(ret);
         std::size_t entry_index = 0;
-        for (std::size_t i = 0; i < num_rows; ++i) {
+        for (std::size_t i = 0; i < numRows(); ++i) {
           ret[entry_index] = {i, i, 2.0};
           entry_index += 1;
         }
-        for (std::size_t i = 1; i < num_rows; ++i) {
+        for (std::size_t i = 1; i < numRows(); ++i) {
           ret[entry_index] = {i, i - 1, -1.0};
           entry_index += 1;
         }
         return ret;
-      }();
+      }
     };
     static constexpr auto sparsity = Sparsity{};
 
     constexpr Value valueAt(const std::size_t i) const {
-      return Sparsity::entries[i].value;
+      return Sparsity::entries()[i].value;
     }
   };
 

--- a/tests/test_matrices/single/lfat5.hpp
+++ b/tests/test_matrices/single/lfat5.hpp
@@ -19,7 +19,7 @@ struct TestMatrixLFAT5 {
          {11, 7},  {12, 7},  {8, 8},   {11, 8},  {12, 8},  {9, 9},
          {10, 10}, {11, 11}, {13, 11}, {12, 12}, {13, 12}, {13, 13}});
 
-    static constexpr std::array<double, sparsity.nnz> values = {
+    static constexpr std::array<double, sparsity.nnz()> values = {
         {1.57088000000000005e+00,  -9.42527999999999935e+01,
          7.85440000000000027e-01,  1.25664000000000000e+07,
          -6.28320000000000000e+06, 6.08806201550387560e-01,

--- a/tests/test_matrices/single/random.hpp
+++ b/tests/test_matrices/single/random.hpp
@@ -18,7 +18,7 @@ struct TestMatrixRandom {
 
   struct Matrix {
     static constexpr auto sparsity = Sparsity(sparsity_in);
-    std::array<Value, sparsity.nnz> values;
+    std::array<Value, sparsity.nnz()> values;
     Value valueAt(const std::size_t entry_index) const {
       return values[entry_index];
     }

--- a/tests/utility/test_sparsity_equal.hpp
+++ b/tests/utility/test_sparsity_equal.hpp
@@ -14,7 +14,7 @@
       sortEntriesRowMajorSorted(entries);                             \
       return entries;                                                 \
     };                                                                \
-    CTLDL_TEST_STATIC(sortedEntries((sparsity_lhs).entries) ==        \
-                          sortedEntries((sparsity_rhs).entries),      \
+    CTLDL_TEST_STATIC(sortedEntries((sparsity_lhs).entries()) ==      \
+                          sortedEntries((sparsity_rhs).entries()),    \
                       boost::test_tools::per_element());              \
   }


### PR DESCRIPTION
Use member functions instead of members directly. With functions we are more flexible to add different sparsity types with the same interface.