### PR TITLE
Split permutation representation

### DIFF
--- a/ctldl/factor_data/empty_factor_data_left.hpp
+++ b/ctldl/factor_data/empty_factor_data_left.hpp
@@ -14,7 +14,7 @@ struct EmptyFactorDataLeft {
   static constexpr auto sparsity = makeEmptySparsityCSR<num_rows, 0>();
   static constexpr std::array<Value, 0> L{};
   static constexpr auto permutation_row = FactorData::permutation_row;
-  static constexpr Permutation<0> permutation_col{};
+  static constexpr PermutationStatic<0> permutation_col{};
 
   static constexpr auto origRowIndex(const std::size_t factor_row_index) {
     return std::size_t{permutation_row[factor_row_index]};

--- a/ctldl/factor_data/factorization.hpp
+++ b/ctldl/factor_data/factorization.hpp
@@ -21,7 +21,7 @@
 namespace ctldl {
 
 template <Sparsity sparsity_orig, class Value_,
-          Permutation<sparsity_orig.numRows()> permutation_in =
+          PermutationStatic<sparsity_orig.numRows()> permutation_in =
               PermutationIdentity{}>
 class Factorization {
  public:

--- a/ctldl/factor_data/factorization_already_permuted.hpp
+++ b/ctldl/factor_data/factorization_already_permuted.hpp
@@ -13,7 +13,7 @@ namespace ctldl {
 // We implement that by unpermuting the sparsity and letting the Factorization
 // permute it back again. That way we factorize the correct sparsity and also
 // remember the correct permutation within Factorization.
-template <Sparsity sparsity, class Value, Permutation permutation>
+template <Sparsity sparsity, class Value, PermutationStatic permutation>
 using FactorizationAlreadyPermuted =
     Factorization<getSparsityLowerTriangle<sparsity>(
                       invertPermutation(permutation)),

--- a/ctldl/factor_data/factorization_repeating_block_tridiagonal.hpp
+++ b/ctldl/factor_data/factorization_repeating_block_tridiagonal.hpp
@@ -24,7 +24,7 @@ namespace ctldl {
 // [      B  A  B']
 // [         B  A ]
 template <Sparsity sparsity_A, Sparsity sparsity_B, class Value_,
-          Permutation<sparsity_A.numRows()> permutation_in =
+          PermutationStatic<sparsity_A.numRows()> permutation_in =
               PermutationIdentity{}>
 class FactorizationRepeatingBlockTridiagonal {
  private:

--- a/ctldl/factor_data/factorization_repeating_block_tridiagonal_arrowhead_linked.hpp
+++ b/ctldl/factor_data/factorization_repeating_block_tridiagonal_arrowhead_linked.hpp
@@ -63,19 +63,19 @@ class FactorizationRepeatingBlockTridiagonalArrowheadLinked {
 
   static constexpr auto sparsity_factor = getFilledInSparsityRepeatingArrowhead<
       sparsity_tridiag_diag, sparsity_tridiag_subdiag, sparsity_outer_subdiag,
-      Permutation<dim_tridiag>{}, Permutation<dim_outer>{}>();
+      PermutationStatic<dim_tridiag>{}, PermutationStatic<dim_outer>{}>();
 
   static constexpr auto helper = [] {
     constexpr auto sparsity_link_tridiag_permuted_cols = getSparsityPermuted(
-        sparsity.link.prev, Permutation<dim_link>{}, permutation_tridiag);
+        sparsity.link.prev, PermutationStatic<dim_link>{}, permutation_tridiag);
     constexpr auto sparsity_link_outer_permuted_rows = getSparsityPermuted(
-        sparsity.link.next, permutation_outer, Permutation<dim_link>{});
+        sparsity.link.next, permutation_outer, PermutationStatic<dim_link>{});
     return getFilledInSparsityBlocked3x3<
         sparsity_factor.diag, sparsity_link_tridiag_permuted_cols,
         sparsity.link.diag, sparsity_factor.outer,
         sparsity_link_outer_permuted_rows, sparsity_outer_diag,
-        Permutation<dim_tridiag>{}, permutation_link,
-        Permutation<dim_outer>{}>();
+        PermutationStatic<dim_tridiag>{}, permutation_link,
+        PermutationStatic<dim_outer>{}>();
   }();
   static constexpr auto sparsity_factor_link_tridiag = helper.block21;
   static constexpr auto sparsity_factor_link_diag = helper.block22;

--- a/ctldl/factor_data/factorization_repeating_block_tridiagonal_arrowhead_linked.test.cpp
+++ b/ctldl/factor_data/factorization_repeating_block_tridiagonal_arrowhead_linked.test.cpp
@@ -56,9 +56,9 @@ BOOST_AUTO_TEST_CASE(Spline) {
   constexpr auto dim_link = std::size_t{0};
   constexpr auto dim_outer = std::size_t{0};
 
-  constexpr Permutation permutation_start{
+  constexpr PermutationStatic permutation_start{
       std::array<std::size_t, dim_start>{0, 1, 2, 3}};
-  constexpr Permutation permutation_tridiag{
+  constexpr PermutationStatic permutation_tridiag{
       std::array<std::size_t, dim_tridiag>{3, 5, 4, 0, 1, 2, 6}};
 
   constexpr auto sparsity = SparsityToFactorizeTridiagonalArrowheadLinked{

--- a/ctldl/factor_data/factorization_subdiagonal_block.hpp
+++ b/ctldl/factor_data/factorization_subdiagonal_block.hpp
@@ -17,9 +17,9 @@
 namespace ctldl {
 
 template <Sparsity sparsity_in, class Value_,
-          Permutation<sparsity_in.numRows()> permutation_row_in =
+          PermutationStatic<sparsity_in.numRows()> permutation_row_in =
               PermutationIdentity{},
-          Permutation<sparsity_in.numCols()> permutation_col_in =
+          PermutationStatic<sparsity_in.numCols()> permutation_col_in =
               PermutationIdentity{}>
 class FactorizationSubdiagonalBlock {
  public:

--- a/ctldl/factor_data/sparsity_to_factorize_link.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_link.hpp
@@ -36,7 +36,7 @@ struct SparsityToFactorizeLink {
   Sparsity<nnz_prev, dim_link, dim_prev_> prev;
   Sparsity<nnz_link, dim_link, dim_link> diag;
   Sparsity<nnz_next, dim_next_, dim_link> next;
-  Permutation<dim_link> permutation = PermutationIdentity{};
+  PermutationStatic<dim_link> permutation = PermutationIdentity{};
 };
 
 template <class Prev, class Diag, class Next,

--- a/ctldl/factor_data/sparsity_to_factorize_outer.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_outer.hpp
@@ -40,7 +40,7 @@ struct SparsityToFactorizeOuter {
   static constexpr auto dim_inner = dim_inner_;
   Sparsity<nnz_subdiag, dim_outer, dim_inner_> subdiag;
   Sparsity<nnz_diag, dim_outer, dim_outer> diag;
-  Permutation<dim_outer> permutation = PermutationIdentity{};
+  PermutationStatic<dim_outer> permutation = PermutationIdentity{};
 };
 
 template <class Subdiag, class Diag, class PermutationIn = PermutationIdentity>

--- a/ctldl/factor_data/sparsity_to_factorize_start.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_start.hpp
@@ -36,7 +36,7 @@ struct SparsityToFactorizeStart {
   Sparsity<nnz_start, dim_start, dim_start> diag;
   Sparsity<nnz_next, dim_next_, dim_start> next;
   Sparsity<nnz_outer, dim_outer_, dim_start> outer;
-  Permutation<dim_start> permutation = PermutationIdentity{};
+  PermutationStatic<dim_start> permutation = PermutationIdentity{};
 };
 
 template <class Diag, class Next, class Outer,

--- a/ctldl/factor_data/sparsity_to_factorize_tridiagonal.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_tridiagonal.hpp
@@ -31,7 +31,7 @@ struct SparsityToFactorizeTridiagonal {
   static constexpr auto dim = dim_;
   Sparsity<nnz_diagonal, dim, dim> diag;
   Sparsity<nnz_subdiagonal, dim, dim> subdiag;
-  Permutation<dim> permutation = PermutationIdentity{};
+  PermutationStatic<dim> permutation = PermutationIdentity{};
 };
 
 template <class SparsityDiag, class SparsitySubdiag,

--- a/ctldl/permutation/invert_permutation.hpp
+++ b/ctldl/permutation/invert_permutation.hpp
@@ -3,22 +3,17 @@
 #include <ctldl/permutation/permutation.hpp>
 #include <ctldl/utility/fix_init_if_zero_length_array.hpp>
 
-#include <array>
 #include <cstddef>
+#include <vector>
 
 namespace ctldl {
 
-template <class PermutationIn>
-constexpr auto invertPermutation(const PermutationIn& permutation) {
-  using std::size;
-  constexpr auto dim = std::size_t{size(PermutationIn{})};
-
-  std::array<std::size_t, dim> inverse_permutation;
-  fixInitIfZeroLengthArray(inverse_permutation);
-  for (std::size_t i = 0; i < dim; ++i) {
+constexpr auto invertPermutation(const PermutationView permutation) {
+  std::vector<std::size_t> inverse_permutation(permutation.size());
+  for (std::size_t i = 0; i < permutation.size(); ++i) {
     inverse_permutation[permutation[i]] = i;
   }
-  return Permutation<dim>{inverse_permutation};
+  return PermutationDynamic(inverse_permutation);
 }
 
 }  // namespace ctldl

--- a/ctldl/permutation/permutation.hpp
+++ b/ctldl/permutation/permutation.hpp
@@ -7,40 +7,85 @@
 #include <array>
 #include <cstddef>
 #include <numeric>
+#include <span>
+#include <vector>
 
 namespace ctldl {
 
 template <std::size_t dim>
-struct Permutation {
+struct PermutationStatic {
   static constexpr std::size_t size() { return dim; }
 
-  constexpr Permutation()
-      : indices([] {
+  constexpr PermutationStatic()
+      : m_indices_do_not_touch([] {
           std::array<std::size_t, dim> permutation;
           fixInitIfZeroLengthArray(permutation);
           std::iota(permutation.begin(), permutation.end(), std::size_t{0});
           return permutation;
         }()) {}
 
-  constexpr explicit Permutation(
+  constexpr explicit PermutationStatic(
       const std::array<std::size_t, dim>& permutation)
-      : indices(permutation) {}
+      : m_indices_do_not_touch(permutation) {}
 
-  constexpr Permutation(const PermutationIdentity) : Permutation() {}
+  constexpr PermutationStatic(const PermutationIdentity)
+      : PermutationStatic() {}
 
-  constexpr auto operator[](const std::size_t i) const { return indices[i]; }
+  constexpr auto operator[](const std::size_t i) const { return indices()[i]; }
 
-  constexpr auto begin() const { return indices.begin(); }
-  constexpr auto end() const { return indices.end(); }
-  constexpr auto cbegin() const { return indices.cbegin(); }
-  constexpr auto cend() const { return indices.cend(); }
+  constexpr auto begin() const { return indices().begin(); }
+  constexpr auto end() const { return indices().end(); }
 
-  std::array<std::size_t, dim> indices;
+  // only public to allow usage as NTTP
+  std::array<std::size_t, dim> m_indices_do_not_touch;
+  constexpr const std::array<std::size_t, dim>& indices() const {
+    return m_indices_do_not_touch;
+  }
 };
 
-template <std::size_t dim>
-constexpr bool operator==(const Permutation<dim>& lhs,
-                          const Permutation<dim>& rhs) {
+class PermutationDynamic {
+ public:
+  constexpr explicit PermutationDynamic(
+      const std::span<const std::size_t> indices)
+      : m_indices(indices.begin(), indices.end()) {}
+
+  constexpr const std::vector<std::size_t>& indices() const {
+    return m_indices;
+  }
+
+  constexpr std::size_t size() const { return m_indices.size(); }
+
+  constexpr auto operator[](const std::size_t i) const { return m_indices[i]; }
+
+  constexpr auto begin() const { return indices().begin(); }
+  constexpr auto end() const { return indices().end(); }
+
+ private:
+  std::vector<std::size_t> m_indices;
+};
+
+class PermutationView {
+ public:
+  template <std::size_t dim>
+  constexpr PermutationView(const PermutationStatic<dim>& permutation)
+      : m_indices(permutation.indices()) {}
+
+  constexpr PermutationView(const PermutationDynamic& permutation)
+      : m_indices(permutation.indices()) {}
+
+  constexpr std::size_t size() const { return m_indices.size(); }
+
+  constexpr auto operator[](const std::size_t i) const { return m_indices[i]; }
+
+  constexpr auto begin() const { return m_indices.begin(); }
+  constexpr auto end() const { return m_indices.end(); }
+
+ private:
+  std::span<const std::size_t> m_indices;
+};
+
+constexpr bool operator==(const PermutationView lhs,
+                          const PermutationView rhs) {
   return std::ranges::equal(lhs, rhs);
 }
 

--- a/ctldl/permutation/permuted_entry.hpp
+++ b/ctldl/permutation/permuted_entry.hpp
@@ -8,10 +8,10 @@
 
 namespace ctldl {
 
-template <class InputEntry, std::size_t num_rows, std::size_t num_cols>
+template <class InputEntry>
 constexpr Entry permutedEntry(const InputEntry entry,
-                              const Permutation<num_rows>& permutation_row,
-                              const Permutation<num_cols>& permutation_col) {
+                              const PermutationView permutation_row,
+                              const PermutationView permutation_col) {
   return Entry{permutation_row[entry.row_index],
                permutation_col[entry.col_index]};
 }

--- a/ctldl/permutation/permuted_entry_lower_triangle.hpp
+++ b/ctldl/permutation/permuted_entry_lower_triangle.hpp
@@ -9,9 +9,9 @@
 
 namespace ctldl {
 
-template <class InputEntry, std::size_t dim>
+template <class InputEntry>
 constexpr Entry permutedEntryLowerTriangle(
-    const InputEntry entry, const Permutation<dim>& permutation) {
+    const InputEntry entry, const PermutationView permutation) {
   return Entry{
       std::max(permutation[entry.row_index], permutation[entry.col_index]),
       std::min(permutation[entry.row_index], permutation[entry.col_index])};

--- a/ctldl/sparsity/is_sparsity_subset.hpp
+++ b/ctldl/sparsity/is_sparsity_subset.hpp
@@ -13,8 +13,10 @@ namespace ctldl {
 template <class SparsityLhs, class SparsityRhs>
 constexpr bool isSparsitySubset(
     const SparsityLhs& sparsity_lhs_in, const SparsityRhs& sparsity_rhs_in,
-    const Permutation<SparsityLhs::numRows()>& permutation_row = {},
-    const Permutation<SparsityLhs::numCols()>& permutation_col = {}) {
+    const PermutationView permutation_row =
+        PermutationStatic<SparsityLhs::numRows()>{},
+    const PermutationView permutation_col =
+        PermutationStatic<SparsityLhs::numCols()>{}) {
   const auto sparsity_lhs = makeSparsityCSR(
       getSparsityPermuted(sparsity_lhs_in, permutation_row, permutation_col));
   const auto sparsity_rhs = makeSparsityCSR(sparsity_rhs_in);
@@ -47,9 +49,9 @@ constexpr bool isSparsitySubset(
   return true;
 }
 
-template <auto sparsity_lhs, class SparsityRhs, class Permutation>
-constexpr bool isSparsitySubsetLowerTriangle(const SparsityRhs& sparsity_rhs,
-                                             const Permutation& permutation) {
+template <auto sparsity_lhs, class SparsityRhs>
+constexpr bool isSparsitySubsetLowerTriangle(
+    const SparsityRhs& sparsity_rhs, const PermutationView permutation) {
   return isSparsitySubset(getSparsityLowerTriangle<sparsity_lhs>(permutation),
                           sparsity_rhs);
 }

--- a/ctldl/sparsity/sparsity_lower_triangle.hpp
+++ b/ctldl/sparsity/sparsity_lower_triangle.hpp
@@ -21,9 +21,9 @@ constexpr auto getNnzLowerTriangle(const Sparsity& sparsity) {
   return nnz;
 }
 
-template <std::size_t nnz, class Sparsity, class PermutationIn>
+template <std::size_t nnz, class Sparsity>
 constexpr auto getEntriesLowerTriangle(const Sparsity& sparsity,
-                                       const PermutationIn& permutation) {
+                                       const PermutationView permutation) {
   static_assert(isSquare<Sparsity>());
   const auto inverse_permutation = invertPermutation(permutation);
 
@@ -41,8 +41,8 @@ constexpr auto getEntriesLowerTriangle(const Sparsity& sparsity,
   return entries;
 }
 
-template <auto sparsity, class PermutationIn>
-constexpr auto getSparsityLowerTriangle(const PermutationIn& permutation) {
+template <auto sparsity>
+constexpr auto getSparsityLowerTriangle(const PermutationView permutation) {
   static_assert(isSquare(sparsity));
   constexpr auto dim = std::size_t{sparsity.numRows()};
   constexpr auto nnz = getNnzLowerTriangle(sparsity);

--- a/ctldl/sparsity/sparsity_permuted.hpp
+++ b/ctldl/sparsity/sparsity_permuted.hpp
@@ -10,10 +10,10 @@
 
 namespace ctldl {
 
-template <class SparsityIn, class PermutationRow, class PermutationCol>
+template <class SparsityIn>
 constexpr auto getSparsityPermuted(const SparsityIn& sparsity,
-                                   const PermutationRow& permutation_row,
-                                   const PermutationCol& permutation_col) {
+                                   const PermutationView permutation_row,
+                                   const PermutationView permutation_col) {
   using std::size;
   constexpr auto nnz = std::size_t{size(decltype(sparsity.entries()){})};
 

--- a/ctldl/symbolic/filled_in_sparsity.hpp
+++ b/ctldl/symbolic/filled_in_sparsity.hpp
@@ -10,7 +10,8 @@
 
 namespace ctldl {
 
-template <auto sparsity, auto permutation = Permutation<sparsity.numRows()>{}>
+template <auto sparsity,
+          auto permutation = PermutationStatic<sparsity.numRows()>{}>
 constexpr auto getFilledInSparsity() {
   static_assert(isSquare(sparsity));
   constexpr auto dim = std::size_t{sparsity.numRows()};

--- a/ctldl/symbolic/filled_in_sparsity_blocked.hpp
+++ b/ctldl/symbolic/filled_in_sparsity_blocked.hpp
@@ -68,9 +68,9 @@ constexpr auto getFilledInNumNonZerosBlocked(const Sparsity11& sparsity11,
 
 template <auto sparsity11_in, auto sparsity21_in, auto sparsity22_in,
           auto sparsity31_in, auto sparsity32_in, auto sparsity33_in,
-          auto permutation1 = Permutation<sparsity11_in.numRows()>(),
-          auto permutation2 = Permutation<sparsity22_in.numRows()>(),
-          auto permutation3 = Permutation<sparsity33_in.numRows()>()>
+          auto permutation1 = PermutationStatic<sparsity11_in.numRows()>(),
+          auto permutation2 = PermutationStatic<sparsity22_in.numRows()>(),
+          auto permutation3 = PermutationStatic<sparsity33_in.numRows()>()>
 constexpr auto getFilledInSparsityBlocked3x3() {
   static_assert(isSquare(sparsity11_in));
   static_assert(isSquare(sparsity22_in));
@@ -155,13 +155,13 @@ constexpr auto getFilledInSparsityBlocked3x3() {
 }
 
 template <auto sparsity11, auto sparsity21, auto sparsity22,
-          auto permutation1 = Permutation<sparsity11.numRows()>(),
-          auto permutation2 = Permutation<sparsity22.numRows()>()>
+          auto permutation1 = PermutationStatic<sparsity11.numRows()>(),
+          auto permutation2 = PermutationStatic<sparsity22.numRows()>()>
 constexpr auto getFilledInSparsityBlocked() {
   constexpr auto sparsity31_dummy = makeEmptySparsity<0, sparsity11.numCols()>();
   constexpr auto sparsity32_dummy = makeEmptySparsity<0, sparsity22.numCols()>();
   constexpr auto sparsity33_dummy = makeEmptySparsity<0, 0>();
-  constexpr auto permutation3_dummy = Permutation<0>{};
+  constexpr auto permutation3_dummy = PermutationStatic<0>{};
   const auto sparsity = getFilledInSparsityBlocked3x3<
       sparsity11, sparsity21, sparsity22, sparsity31_dummy, sparsity32_dummy,
       sparsity33_dummy, permutation1, permutation2, permutation3_dummy>();

--- a/ctldl/symbolic/filled_in_sparsity_repeating.hpp
+++ b/ctldl/symbolic/filled_in_sparsity_repeating.hpp
@@ -16,10 +16,9 @@ constexpr auto getFilledInSparsityRepeating() {
   static_assert(sparsity_in_B.numRows() == sparsity_in_A.numRows());
   constexpr auto dim = std::size_t{sparsity_in_A.numRows()};
 
-  const auto sparsity_filled =
-      getFilledInSparsityRepeatingArrowhead<sparsity_in_A, sparsity_in_B,
-                                            makeEmptySparsity<0, dim>(),
-                                            permutation, Permutation<0>{}>();
+  const auto sparsity_filled = getFilledInSparsityRepeatingArrowhead<
+      sparsity_in_A, sparsity_in_B, makeEmptySparsity<0, dim>(), permutation,
+      PermutationStatic<0>{}>();
   return RepeatingBlockTridiagonal{sparsity_filled.diag,
                                    sparsity_filled.subdiag};
 };

--- a/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.test.cpp
+++ b/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.test.cpp
@@ -13,7 +13,7 @@ namespace {
 
 BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadEmptyTest) {
   constexpr auto empty = makeEmptySparsity<1, 1>();
-  constexpr Permutation<1> permutation{};
+  constexpr PermutationStatic<1> permutation{};
   constexpr auto filled =
       getFilledInSparsityRepeatingArrowhead<empty, empty, empty, permutation,
                                             permutation>();
@@ -24,8 +24,8 @@ BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadFromDiagonalTest) {
   constexpr auto sparsity_A = makeSparsity<3, 3>({{1, 0}, {2, 1}});
   constexpr auto sparsity_B = makeEmptySparsity<3, 3>();
   constexpr auto sparsity_C = makeSparsity<1, 3>({{0, 0}});
-  constexpr Permutation<3> permutation{};
-  constexpr Permutation<1> permutation_outer{};
+  constexpr PermutationStatic<3> permutation{};
+  constexpr PermutationStatic<1> permutation_outer{};
   constexpr auto filled =
       getFilledInSparsityRepeatingArrowhead<sparsity_A, sparsity_B, sparsity_C,
                                             permutation, permutation_outer>();
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadFromBothTest) {
   constexpr auto sparsity_A = makeSparsity<3, 3>({{2, 1}});
   constexpr auto sparsity_B = makeSparsity<3, 3>({{1, 0}});
   constexpr auto sparsity_C = makeSparsity<1, 3>({{0, 0}});
-  constexpr Permutation<3> permutation{};
-  constexpr Permutation<1> permutation_outer{};
+  constexpr PermutationStatic<3> permutation{};
+  constexpr PermutationStatic<1> permutation_outer{};
   constexpr auto filled =
       getFilledInSparsityRepeatingArrowhead<sparsity_A, sparsity_B, sparsity_C,
                                             permutation, permutation_outer>();
@@ -52,8 +52,8 @@ BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadBackwardsTest) {
   constexpr auto sparsity_A = makeEmptySparsity<4, 4>();
   constexpr auto sparsity_B = makeSparsity<4, 4>({{0, 1}, {1, 2}, {2, 3}});
   constexpr auto sparsity_C = makeSparsity<1, 4>({{0, 3}});
-  constexpr Permutation<4> permutation{};
-  constexpr Permutation<1> permutation_outer{};
+  constexpr PermutationStatic<4> permutation{};
+  constexpr PermutationStatic<1> permutation_outer{};
   constexpr auto filled =
       getFilledInSparsityRepeatingArrowhead<sparsity_A, sparsity_B, sparsity_C,
                                             permutation, permutation_outer>();

--- a/examples/repeating/example_indef.cpp
+++ b/examples/repeating/example_indef.cpp
@@ -47,7 +47,7 @@ struct MatrixB {
   }
 };
 
-constexpr ctldl::Permutation<dim> permutation{{0, 1}};
+constexpr ctldl::PermutationStatic<dim> permutation{{0, 1}};
 
 }  // anonymous namespace
 

--- a/examples/repeating/example_nos2.cpp
+++ b/examples/repeating/example_nos2.cpp
@@ -53,7 +53,7 @@ struct MatrixB {
   }
 };
 
-constexpr ctldl::Permutation<dim> permutation{{0, 1, 2}};
+constexpr ctldl::PermutationStatic<dim> permutation{{0, 1, 2}};
 
 }  // anonymous namespace
 

--- a/examples/repeating/example_nos4.cpp
+++ b/examples/repeating/example_nos4.cpp
@@ -91,7 +91,7 @@ struct MatrixB {
   }
 };
 
-constexpr ctldl::Permutation<dim> permutation{{7, 8, 0, 4, 3, 2, 6, 5, 9, 1}};
+constexpr ctldl::PermutationStatic<dim> permutation{{7, 8, 0, 4, 3, 2, 6, 5, 9, 1}};
 
 }  // anonymous namespace
 

--- a/examples/repeating/mtx_includes/suitesparse/Bai/mhdb416/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/suitesparse/Bai/mhdb416/ctldl_repeating_mtx_include.hpp
@@ -14,7 +14,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
   constexpr auto next = ctldl::makeEmptySparsity<16, 0>();
   constexpr auto outer = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeStart{diag, next, outer, permutation};
 }
 
@@ -29,7 +29,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
        {5, 5},   {6, 5},   {7, 5},   {4, 7},   {5, 7},   {6, 7},   {7, 7},
        {8, 9},   {9, 9},   {10, 11}, {11, 11}, {12, 12}, {13, 12}, {12, 13},
        {13, 13}, {14, 14}, {15, 14}, {14, 15}, {15, 15}});
-  constexpr auto permutation = ctldl::Permutation<16>{
+  constexpr auto permutation = ctldl::PermutationStatic<16>{
       {0, 1, 2, 3, 4, 6, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15}};
   return ctldl::SparsityToFactorizeTridiagonal{diag, subdiag, permutation};
 }
@@ -38,13 +38,13 @@ constexpr auto getRepeatingMtxSparsityLink() {
   constexpr auto prev = ctldl::makeEmptySparsity<0, 16>();
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
   constexpr auto next = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeLink{prev, diag, next, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityOuter() {
   constexpr auto subdiag = ctldl::makeEmptySparsity<0, 16>();
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeOuter{subdiag, diag, permutation};
 }

--- a/examples/repeating/mtx_includes/suitesparse/HB/nos2/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/suitesparse/HB/nos2/ctldl_repeating_mtx_include.hpp
@@ -14,7 +14,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
   constexpr auto next = ctldl::makeEmptySparsity<3, 0>();
   constexpr auto outer = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeStart{diag, next, outer, permutation};
 }
 
@@ -22,7 +22,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
   constexpr auto diag = ctldl::makeSparsity<3, 3>({{0, 0}, {1, 1}, {2, 2}});
   constexpr auto subdiag =
       ctldl::makeSparsity<3, 3>({{0, 0}, {1, 1}, {2, 1}, {1, 2}, {2, 2}});
-  constexpr auto permutation = ctldl::Permutation<3>{{0, 1, 2}};
+  constexpr auto permutation = ctldl::PermutationStatic<3>{{0, 1, 2}};
   return ctldl::SparsityToFactorizeTridiagonal{diag, subdiag, permutation};
 }
 
@@ -30,13 +30,13 @@ constexpr auto getRepeatingMtxSparsityLink() {
   constexpr auto prev = ctldl::makeEmptySparsity<0, 3>();
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
   constexpr auto next = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeLink{prev, diag, next, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityOuter() {
   constexpr auto subdiag = ctldl::makeEmptySparsity<0, 3>();
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeOuter{subdiag, diag, permutation};
 }

--- a/examples/repeating/mtx_includes/suitesparse/HB/nos4/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/suitesparse/HB/nos4/ctldl_repeating_mtx_include.hpp
@@ -14,7 +14,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
   constexpr auto next = ctldl::makeEmptySparsity<10, 0>();
   constexpr auto outer = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeStart{diag, next, outer, permutation};
 }
 
@@ -61,7 +61,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
     {9,9},
   });
   constexpr auto permutation =
-      ctldl::Permutation<10>{{7, 8, 0, 4, 3, 2, 6, 5, 9, 1}};
+      ctldl::PermutationStatic<10>{{7, 8, 0, 4, 3, 2, 6, 5, 9, 1}};
   return ctldl::SparsityToFactorizeTridiagonal{diag, subdiag, permutation};
 }
 
@@ -69,13 +69,13 @@ constexpr auto getRepeatingMtxSparsityLink() {
   constexpr auto prev = ctldl::makeEmptySparsity<0, 10>();
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
   constexpr auto next = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeLink{prev, diag, next, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityOuter() {
   constexpr auto subdiag = ctldl::makeEmptySparsity<0, 10>();
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeOuter{subdiag, diag, permutation};
 }

--- a/examples/repeating/mtx_includes/transworhp/laufkatze/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/transworhp/laufkatze/ctldl_repeating_mtx_include.hpp
@@ -58,7 +58,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
     {0,9},
     {0,10},
   });
-  constexpr auto permutation = ctldl::Permutation<11>{{
+  constexpr auto permutation = ctldl::PermutationStatic<11>{{
     0,
     1,
     2,
@@ -137,7 +137,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
     {7,19},
     {8,19},
   });
-  constexpr auto permutation = ctldl::Permutation<20>{{
+  constexpr auto permutation = ctldl::PermutationStatic<20>{{
     9,
     17,
     10,
@@ -166,7 +166,7 @@ constexpr auto getRepeatingMtxSparsityLink() {
   constexpr auto prev = ctldl::makeEmptySparsity<0, 20>();
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
   constexpr auto next = ctldl::makeEmptySparsity<1, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeLink{prev, diag, next, permutation};
 }
 
@@ -194,7 +194,7 @@ constexpr auto getRepeatingMtxSparsityOuter() {
   constexpr auto diag = ctldl::makeSparsity<1, 1>({
     {0,0},
   });
-  constexpr auto permutation = ctldl::Permutation<1>{{
+  constexpr auto permutation = ctldl::PermutationStatic<1>{{
     0,
   }};
   return ctldl::SparsityToFactorizeOuter{subdiag, diag, permutation};

--- a/examples/repeating/mtx_includes/transworhp/opal/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/transworhp/opal/ctldl_repeating_mtx_include.hpp
@@ -14,7 +14,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
   constexpr auto next = ctldl::makeEmptySparsity<22, 0>();
   constexpr auto outer = ctldl::makeEmptySparsity<2, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeStart{diag, next, outer, permutation};
 }
 
@@ -108,7 +108,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
     {4,21},
     {7,21},
   });
-  constexpr auto permutation = ctldl::Permutation<22>{{
+  constexpr auto permutation = ctldl::PermutationStatic<22>{{
     10,
     11,
     12,
@@ -199,7 +199,7 @@ constexpr auto getRepeatingMtxSparsityLink() {
     {0,8},
     {0,9},
   });
-  constexpr auto permutation = ctldl::Permutation<14>{{
+  constexpr auto permutation = ctldl::PermutationStatic<14>{{
     4,
     5,
     6,
@@ -252,7 +252,7 @@ constexpr auto getRepeatingMtxSparsityOuter() {
     {0,0},
     {1,1},
   });
-  constexpr auto permutation = ctldl::Permutation<2>{{
+  constexpr auto permutation = ctldl::PermutationStatic<2>{{
     0,
     1,
   }};

--- a/examples/repeating/mtx_includes/transworhp/spline/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/transworhp/spline/ctldl_repeating_mtx_include.hpp
@@ -26,7 +26,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
     {2,3},
   });
   constexpr auto outer = ctldl::makeEmptySparsity<0, 4>();
-  constexpr auto permutation = ctldl::Permutation<4>{{
+  constexpr auto permutation = ctldl::PermutationStatic<4>{{
     0,
     1,
     2,
@@ -59,7 +59,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
     {1,6},
     {2,6},
   });
-  constexpr auto permutation = ctldl::Permutation<7>{{
+  constexpr auto permutation = ctldl::PermutationStatic<7>{{
     3,
     5,
     4,
@@ -75,13 +75,13 @@ constexpr auto getRepeatingMtxSparsityLink() {
   constexpr auto prev = ctldl::makeEmptySparsity<0, 7>();
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
   constexpr auto next = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeLink{prev, diag, next, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityOuter() {
   constexpr auto subdiag = ctldl::makeEmptySparsity<0, 7>();
   constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr ctldl::Permutation<0> permutation{};
+  constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeOuter{subdiag, diag, permutation};
 }

--- a/examples/single/example_indef_single.cpp
+++ b/examples/single/example_indef_single.cpp
@@ -12,7 +12,7 @@
 namespace {
 
 constexpr int dim = 2;
-constexpr ctldl::Permutation<dim> permutation{{0, 1}};
+constexpr ctldl::PermutationStatic<dim> permutation{{0, 1}};
 
 struct Matrix {
   static constexpr auto sparsity = ctldl::makeSparsity<dim, dim>({{1, 0}});

--- a/examples/single/example_lfat5.cpp
+++ b/examples/single/example_lfat5.cpp
@@ -14,7 +14,7 @@
 namespace {
 
 constexpr int dim = 14;
-constexpr ctldl::Permutation<dim> permutation{
+constexpr ctldl::PermutationStatic<dim> permutation{
     {13, 11, 12, 8, 7, 0, 4, 3, 9, 1, 5, 10, 2, 6}};
 
 struct Matrix {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(tests_integration
     multiply_factorize_solve_correct/single/small_examples_all_permutations.cpp
     runner_tests_integration.cpp
     utility/solution_generator.cpp
+    utility/to_test_info.cpp
 )
 target_link_libraries(tests_integration PRIVATE
     ctldl::ctldl

--- a/tests/multiply_factorize_solve_correct/repeating/test_functor.hpp
+++ b/tests/multiply_factorize_solve_correct/repeating/test_functor.hpp
@@ -34,7 +34,7 @@ struct TesterMultiplyFactorizeSolveCorrectRepeating {
     static_assert(isSquare(sparsity_B));
     static_assert(sparsity_B.numRows() == sparsity_A.numRows());
     constexpr auto block_dim = std::size_t{sparsity_A.numRows()};
-    constexpr Permutation<block_dim> permutation(PermutationIn::value);
+    constexpr PermutationStatic<block_dim> permutation(PermutationIn::value);
 
     const auto matrices_A =
         generateMatrices(TestMatrixA{}, value_generator, num_repetitions + 1);

--- a/tests/multiply_factorize_solve_correct/repeating_arrowhead_linked/test_functor.hpp
+++ b/tests/multiply_factorize_solve_correct/repeating_arrowhead_linked/test_functor.hpp
@@ -47,10 +47,10 @@ struct TesterMultiplyFactorizeSolveCorrectRepeatingBlockTridiagonalArrowheadLink
     constexpr auto dim_link = std::size_t{TestMatrixLinkDiag::Matrix::sparsity.numRows()};
     constexpr auto dim_outer = std::size_t{TestMatrixOuterDiag::Matrix::sparsity.numRows()};
 
-    constexpr Permutation<dim_start> permutation_start{PermutationStart::value};
-    constexpr Permutation<dim_tridiag> permutation_tridiag{PermutationTridiag::value};
-    constexpr Permutation<dim_link> permutation_link{PermutationLink::value};
-    constexpr Permutation<dim_outer> permutation_outer{PermutationOuter::value};
+    constexpr PermutationStatic<dim_start> permutation_start{PermutationStart::value};
+    constexpr PermutationStatic<dim_tridiag> permutation_tridiag{PermutationTridiag::value};
+    constexpr PermutationStatic<dim_link> permutation_link{PermutationLink::value};
+    constexpr PermutationStatic<dim_outer> permutation_outer{PermutationOuter::value};
 
     constexpr auto sparsity = SparsityToFactorizeTridiagonalArrowheadLinked{
         SparsityToFactorizeStart{

--- a/tests/multiply_factorize_solve_correct/single/test_functor.hpp
+++ b/tests/multiply_factorize_solve_correct/single/test_functor.hpp
@@ -23,7 +23,7 @@ struct TesterMultiplyFactorizeSolveCorrectSingle {
                   std::mt19937& value_generator) const {
     constexpr auto& sparsity = TestMatrix::Matrix::sparsity;
     constexpr auto dim = sparsity.numRows();
-    constexpr Permutation<dim> permutation(PermutationIn::value);
+    constexpr PermutationStatic<dim> permutation(PermutationIn::value);
 
     auto test_matrix = generateMatrix(TestMatrix{}, value_generator);
     Factorization<sparsity, Value, permutation> factorization;

--- a/tests/utility/random/procedural_test_permutation.hpp
+++ b/tests/utility/random/procedural_test_permutation.hpp
@@ -6,19 +6,20 @@
 
 #include <ctldl/permutation/permutation.hpp>
 
+#include <array>
 #include <cstddef>
 
 namespace ctldl {
 
 template <std::size_t dim>
 struct PermutationDistribution {
-  using result_type = Permutation<dim>;
+  using result_type = PermutationStatic<dim>;
 
   template <class Generator>
   constexpr auto operator()(Generator& generator) const {
-    Permutation<dim> permutation;
-    shuffle(permutation.indices.begin(), permutation.indices.end(), generator);
-    return permutation;
+    std::array<std::size_t, dim> indices = PermutationStatic<dim>().indices();
+    shuffle(indices.begin(), indices.end(), generator);
+    return PermutationStatic<dim>(indices);
   }
 };
 

--- a/tests/utility/random/procedural_test_permutation.test.cpp
+++ b/tests/utility/random/procedural_test_permutation.test.cpp
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_CASE(ProceduralTestPermutationTest) {
   constexpr int seed = 0;
   constexpr int dim = 5;
   constexpr auto permutation = ProceduralTestPermutation<seed, dim>{}.value;
-  constexpr Permutation<dim> permutation_identity;
+  constexpr PermutationStatic<dim> permutation_identity;
   CTLDL_TEST_STATIC(
       std::ranges::is_permutation(permutation, permutation_identity));
 }

--- a/tests/utility/to_test_info.cpp
+++ b/tests/utility/to_test_info.cpp
@@ -1,0 +1,22 @@
+#include "to_test_info.hpp"
+
+#include <sstream>
+
+namespace ctldl {
+
+std::string toTestInfo(const PermutationView permutation) {
+  const auto dim = std::size_t{permutation.size()};
+  if (dim == 0) {
+    return "[]";
+  }
+
+  std::stringstream sstream;
+  sstream << '[' << permutation[0];
+  for (std::size_t i = 1; i < dim; ++i) {
+    sstream << ' ' << permutation[i];
+  }
+  sstream << ']';
+  return sstream.str();
+}
+
+}  // namespace ctldl

--- a/tests/utility/to_test_info.hpp
+++ b/tests/utility/to_test_info.hpp
@@ -2,25 +2,11 @@
 
 #include <ctldl/permutation/permutation.hpp>
 
-#include <sstream>
 #include <string>
 
 namespace ctldl {
 
-template <std::size_t dim>
-std::string toTestInfo(const Permutation<dim>& permutation) {
-  if constexpr (dim == 0) {
-    return "[]";
-  }
-
-  std::stringstream sstream;
-  sstream << '[' << permutation[0];
-  for (std::size_t i = 1; i < dim; ++i) {
-    sstream << ' ' << permutation[i];
-  }
-  sstream << ']';
-  return sstream.str();
-}
+std::string toTestInfo(PermutationView permutation);
 
 inline const char* toTestInfo(double) { return "double"; }
 inline const char* toTestInfo(float) { return "float"; }


### PR DESCRIPTION
Make a distinction between Permutation with static size (needed for compile-time determination of sparsity), Permutation with dynamic size and simple view. This allows removing some templating.