### PR TITLE
Split sparsity representation

### DIFF
--- a/ctldl/factor_data/empty_factor_data_diagonal.hpp
+++ b/ctldl/factor_data/empty_factor_data_diagonal.hpp
@@ -8,7 +8,7 @@ namespace ctldl {
 
 template <class FactorData>
 struct EmptyFactorDataDiagonal {
-  static constexpr auto sparsity = makeEmptySparsityCSR<0, 0>();
+  static constexpr auto sparsity = makeEmptySparsityStaticCSR<0, 0>();
   using Value = typename FactorData::Value;
   static constexpr std::array<Value, 0> D{};
 };

--- a/ctldl/factor_data/empty_factor_data_left.hpp
+++ b/ctldl/factor_data/empty_factor_data_left.hpp
@@ -11,7 +11,7 @@ template <class FactorData>
 struct EmptyFactorDataLeft {
   static constexpr auto num_rows = FactorData::sparsity.numRows();
   using Value = typename FactorData::Value;
-  static constexpr auto sparsity = makeEmptySparsityCSR<num_rows, 0>();
+  static constexpr auto sparsity = makeEmptySparsityStaticCSR<num_rows, 0>();
   static constexpr std::array<Value, 0> L{};
   static constexpr auto permutation_row = FactorData::permutation_row;
   static constexpr PermutationStatic<0> permutation_col{};

--- a/ctldl/factor_data/factorization.hpp
+++ b/ctldl/factor_data/factorization.hpp
@@ -20,7 +20,7 @@
 
 namespace ctldl {
 
-template <Sparsity sparsity_orig, class Value_,
+template <SparsityStatic sparsity_orig, class Value_,
           PermutationStatic<sparsity_orig.numRows()> permutation_in =
               PermutationIdentity{}>
 class Factorization {
@@ -59,7 +59,7 @@ class Factorization {
   }
 
   static constexpr auto sparsity =
-      SparsityCSR(getFilledInSparsity<sparsity_orig, permutation>());
+      SparsityStaticCSR(getFilledInSparsity<sparsity_orig, permutation>());
   static constexpr auto nnz = std::size_t{sparsity.nnz()};
   static constexpr auto permutation_row = permutation;
   static constexpr auto permutation_col = permutation;

--- a/ctldl/factor_data/factorization_already_permuted.hpp
+++ b/ctldl/factor_data/factorization_already_permuted.hpp
@@ -13,9 +13,9 @@ namespace ctldl {
 // We implement that by unpermuting the sparsity and letting the Factorization
 // permute it back again. That way we factorize the correct sparsity and also
 // remember the correct permutation within Factorization.
-template <Sparsity sparsity, class Value, PermutationStatic permutation>
+template <SparsityStatic sparsity, class Value, PermutationStatic permutation>
 using FactorizationAlreadyPermuted =
-    Factorization<getSparsityLowerTriangle<sparsity>(
+    Factorization<getSparsityStaticLowerTriangle<sparsity>(
                       invertPermutation(permutation)),
                   Value, permutation>;
 

--- a/ctldl/factor_data/factorization_repeating_block_tridiagonal.hpp
+++ b/ctldl/factor_data/factorization_repeating_block_tridiagonal.hpp
@@ -23,7 +23,7 @@ namespace ctldl {
 // [   :  :  :    ]
 // [      B  A  B']
 // [         B  A ]
-template <Sparsity sparsity_A, Sparsity sparsity_B, class Value_,
+template <SparsityStatic sparsity_A, SparsityStatic sparsity_B, class Value_,
           PermutationStatic<sparsity_A.numRows()> permutation_in =
               PermutationIdentity{}>
 class FactorizationRepeatingBlockTridiagonal {

--- a/ctldl/factor_data/factorization_repeating_block_tridiagonal_arrowhead_linked.hpp
+++ b/ctldl/factor_data/factorization_repeating_block_tridiagonal_arrowhead_linked.hpp
@@ -56,7 +56,7 @@ class FactorizationRepeatingBlockTridiagonalArrowheadLinked {
   static constexpr auto sparsity_factor_start_tridiag = helper_start.block21;
   static constexpr auto sparsity_factor_start_outer = helper_start.block31;
   static constexpr auto sparsity_tridiag_diag = helper_start.block22;
-  static constexpr auto sparsity_tridiag_subdiag = getSparsityPermuted(
+  static constexpr auto sparsity_tridiag_subdiag = getSparsityStaticPermuted(
       sparsity.tridiag.subdiag, permutation_tridiag, permutation_tridiag);
   static constexpr auto sparsity_outer_subdiag = helper_start.block32;
   static constexpr auto sparsity_outer_diag = helper_start.block33;
@@ -66,10 +66,13 @@ class FactorizationRepeatingBlockTridiagonalArrowheadLinked {
       PermutationStatic<dim_tridiag>{}, PermutationStatic<dim_outer>{}>();
 
   static constexpr auto helper = [] {
-    constexpr auto sparsity_link_tridiag_permuted_cols = getSparsityPermuted(
-        sparsity.link.prev, PermutationStatic<dim_link>{}, permutation_tridiag);
-    constexpr auto sparsity_link_outer_permuted_rows = getSparsityPermuted(
-        sparsity.link.next, permutation_outer, PermutationStatic<dim_link>{});
+    constexpr auto sparsity_link_tridiag_permuted_cols =
+        getSparsityStaticPermuted(sparsity.link.prev,
+                                  PermutationStatic<dim_link>{},
+                                  permutation_tridiag);
+    constexpr auto sparsity_link_outer_permuted_rows =
+        getSparsityStaticPermuted(sparsity.link.next, permutation_outer,
+                                  PermutationStatic<dim_link>{});
     return getFilledInSparsityBlocked3x3<
         sparsity_factor.diag, sparsity_link_tridiag_permuted_cols,
         sparsity.link.diag, sparsity_factor.outer,

--- a/ctldl/factor_data/factorization_repeating_block_tridiagonal_arrowhead_linked.test.cpp
+++ b/ctldl/factor_data/factorization_repeating_block_tridiagonal_arrowhead_linked.test.cpp
@@ -20,29 +20,30 @@ BOOST_AUTO_TEST_CASE(SplinePrepermuted) {
 
   constexpr auto sparsity = SparsityToFactorizeTridiagonalArrowheadLinked{
       SparsityToFactorizeStart{
-          makeEmptySparsity<dim_start, dim_start>(),
-          makeSparsity<dim_tridiag, dim_start>(
+          makeEmptySparsityStatic<dim_start, dim_start>(),
+          makeSparsityStatic<dim_tridiag, dim_start>(
               {{3, 0}, {3, 1}, {4, 1}, {4, 3}, {5, 2}, {5, 3}}),
-          makeEmptySparsity<dim_outer, dim_start>()},
+          makeEmptySparsityStatic<dim_outer, dim_start>()},
       SparsityToFactorizeTridiagonal{
-          makeSparsity<dim_tridiag, dim_tridiag>(
+          makeSparsityStatic<dim_tridiag, dim_tridiag>(
               {{3, 0}, {3, 2}, {4, 2}, {5, 1}, {6, 4}, {6, 5}}),
-          makeSparsity<dim_tridiag, dim_tridiag>(
+          makeSparsityStatic<dim_tridiag, dim_tridiag>(
               {{3, 0}, {3, 2}, {4, 2}, {4, 6}, {5, 1}, {5, 6}})},
-      SparsityToFactorizeLink{makeEmptySparsity<dim_link, dim_tridiag>(),
-                              makeEmptySparsity<dim_link, dim_link>(),
-                              makeEmptySparsity<dim_outer, dim_link>()},
-      SparsityToFactorizeOuter{makeEmptySparsity<dim_outer, dim_tridiag>(),
-                               makeEmptySparsity<dim_outer, dim_outer>()}};
+      SparsityToFactorizeLink{makeEmptySparsityStatic<dim_link, dim_tridiag>(),
+                              makeEmptySparsityStatic<dim_link, dim_link>(),
+                              makeEmptySparsityStatic<dim_outer, dim_link>()},
+      SparsityToFactorizeOuter{
+          makeEmptySparsityStatic<dim_outer, dim_tridiag>(),
+          makeEmptySparsityStatic<dim_outer, dim_outer>()}};
 
   using Factorization =
       FactorizationRepeatingBlockTridiagonalArrowheadLinked<sparsity, double>;
 
-  constexpr auto diag_correct = makeSparsity<dim_tridiag, dim_tridiag>(
+  constexpr auto diag_correct = makeSparsityStatic<dim_tridiag, dim_tridiag>(
       {{3, 0}, {3, 2}, {4, 2}, {4, 3}, {5, 1}, {5, 3}, {5, 4}, {6, 4}, {6, 5}});
   CTLDL_TEST_STATIC(isSparsityEqual(Factorization::FactorTridiagDiag::sparsity,
                                     diag_correct));
-  constexpr auto subdiag_correct = makeSparsity<dim_tridiag, dim_tridiag>(
+  constexpr auto subdiag_correct = makeSparsityStatic<dim_tridiag, dim_tridiag>(
     {{3, 0},         {3, 2}, {3, 3}, {3, 4}, {3, 5}, {3, 6},
                      {4, 2}, {4, 3}, {4, 4}, {4, 5}, {4, 6},
              {5, 1},                         {5, 5}, {5, 6}});
@@ -63,33 +64,34 @@ BOOST_AUTO_TEST_CASE(Spline) {
 
   constexpr auto sparsity = SparsityToFactorizeTridiagonalArrowheadLinked{
       SparsityToFactorizeStart{
-          makeEmptySparsity<dim_start, dim_start>(),
-          makeSparsity<dim_tridiag, dim_start>(
+          makeEmptySparsityStatic<dim_start, dim_start>(),
+          makeSparsityStatic<dim_tridiag, dim_start>(
               {{0, 0}, {0, 1}, {1, 1}, {1, 3}, {2, 2}, {2, 3}}),
-          makeEmptySparsity<dim_outer, dim_start>(),
+          makeEmptySparsityStatic<dim_outer, dim_start>(),
           permutation_start,
       },
       SparsityToFactorizeTridiagonal{
-          makeSparsity<dim_tridiag, dim_tridiag>(
+          makeSparsityStatic<dim_tridiag, dim_tridiag>(
               {{3, 0}, {4, 0}, {4, 1}, {5, 2}, {6, 1}, {6, 2}}),
-          makeSparsity<dim_tridiag, dim_tridiag>(
+          makeSparsityStatic<dim_tridiag, dim_tridiag>(
               {{0, 3}, {0, 4}, {1, 4}, {1, 6}, {2, 5}, {2, 6}}),
           permutation_tridiag,
       },
-      SparsityToFactorizeLink{makeEmptySparsity<dim_link, dim_tridiag>(),
-                              makeEmptySparsity<dim_link, dim_link>(),
-                              makeEmptySparsity<dim_outer, dim_link>()},
-      SparsityToFactorizeOuter{makeEmptySparsity<dim_outer, dim_tridiag>(),
-                               makeEmptySparsity<dim_outer, dim_outer>()}};
+      SparsityToFactorizeLink{makeEmptySparsityStatic<dim_link, dim_tridiag>(),
+                              makeEmptySparsityStatic<dim_link, dim_link>(),
+                              makeEmptySparsityStatic<dim_outer, dim_link>()},
+      SparsityToFactorizeOuter{
+          makeEmptySparsityStatic<dim_outer, dim_tridiag>(),
+          makeEmptySparsityStatic<dim_outer, dim_outer>()}};
 
   using Factorization =
       FactorizationRepeatingBlockTridiagonalArrowheadLinked<sparsity, double>;
 
-  constexpr auto diag_correct = makeSparsity<dim_tridiag, dim_tridiag>(
+  constexpr auto diag_correct = makeSparsityStatic<dim_tridiag, dim_tridiag>(
       {{3, 0}, {3, 2}, {4, 2}, {4, 3}, {5, 1}, {5, 3}, {5, 4}, {6, 4}, {6, 5}});
   CTLDL_TEST_STATIC(isSparsityEqual(Factorization::FactorTridiagDiag::sparsity,
                                     diag_correct));
-  constexpr auto subdiag_correct = makeSparsity<dim_tridiag, dim_tridiag>(
+  constexpr auto subdiag_correct = makeSparsityStatic<dim_tridiag, dim_tridiag>(
     {{3, 0},         {3, 2}, {3, 3}, {3, 4}, {3, 5}, {3, 6},
                      {4, 2}, {4, 3}, {4, 4}, {4, 5}, {4, 6},
              {5, 1},                         {5, 5}, {5, 6}});

--- a/ctldl/factor_data/factorization_subdiagonal_block.hpp
+++ b/ctldl/factor_data/factorization_subdiagonal_block.hpp
@@ -16,14 +16,14 @@
 
 namespace ctldl {
 
-template <Sparsity sparsity_in, class Value_,
+template <SparsityStatic sparsity_in, class Value_,
           PermutationStatic<sparsity_in.numRows()> permutation_row_in =
               PermutationIdentity{},
           PermutationStatic<sparsity_in.numCols()> permutation_col_in =
               PermutationIdentity{}>
 class FactorizationSubdiagonalBlock {
  public:
-  static constexpr auto sparsity = makeSparsityCSR(sparsity_in);
+  static constexpr auto sparsity = makeSparsityStaticCSR(sparsity_in);
   static constexpr auto nnz = std::size_t{sparsity.nnz()};
   static constexpr auto num_rows = std::size_t{sparsity.numRows()};
   static constexpr auto num_cols = std::size_t{sparsity.numCols()};

--- a/ctldl/factor_data/sparsity_to_factorize_link.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_link.hpp
@@ -33,25 +33,27 @@ struct SparsityToFactorizeLink {
   static constexpr auto dim_prev = dim_prev_;
   static constexpr auto dim = dim_link;
   static constexpr auto dim_next = dim_next_;
-  Sparsity<nnz_prev, dim_link, dim_prev_> prev;
-  Sparsity<nnz_link, dim_link, dim_link> diag;
-  Sparsity<nnz_next, dim_next_, dim_link> next;
+  SparsityStatic<nnz_prev, dim_link, dim_prev_> prev;
+  SparsityStatic<nnz_link, dim_link, dim_link> diag;
+  SparsityStatic<nnz_next, dim_next_, dim_link> next;
   PermutationStatic<dim_link> permutation = PermutationIdentity{};
 };
 
 template <class Prev, class Diag, class Next,
           class PermutationIn = PermutationIdentity>
 SparsityToFactorizeLink(Prev, Diag, Next, PermutationIn = PermutationIdentity{})
-    -> SparsityToFactorizeLink<
-        ctad_t<Sparsity, Prev>::numCols(), ctad_t<Sparsity, Diag>::numRows(),
-        ctad_t<Sparsity, Next>::numRows(), ctad_t<Sparsity, Prev>::nnz(),
-        ctad_t<Sparsity, Diag>::nnz(), ctad_t<Sparsity, Next>::nnz()>;
+    -> SparsityToFactorizeLink<ctad_t<SparsityStatic, Prev>::numCols(),
+                               ctad_t<SparsityStatic, Diag>::numRows(),
+                               ctad_t<SparsityStatic, Next>::numRows(),
+                               ctad_t<SparsityStatic, Prev>::nnz(),
+                               ctad_t<SparsityStatic, Diag>::nnz(),
+                               ctad_t<SparsityStatic, Next>::nnz()>;
 
 template <std::size_t dim_prev, std::size_t dim_link, std::size_t dim_next>
 constexpr auto makeEmptySparsityToFactorizeLink() {
-  return SparsityToFactorizeLink{makeEmptySparsity<dim_link, dim_prev>(),
-                                 makeEmptySparsity<dim_link, dim_link>(),
-                                 makeEmptySparsity<dim_next, dim_link>()};
+  return SparsityToFactorizeLink{makeEmptySparsityStatic<dim_link, dim_prev>(),
+                                 makeEmptySparsityStatic<dim_link, dim_link>(),
+                                 makeEmptySparsityStatic<dim_next, dim_link>()};
 }
 
 }  // namespace ctldl

--- a/ctldl/factor_data/sparsity_to_factorize_outer.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_outer.hpp
@@ -38,21 +38,23 @@ template <std::size_t dim_inner_, std::size_t dim_outer,
 struct SparsityToFactorizeOuter {
   static constexpr auto dim = dim_outer;
   static constexpr auto dim_inner = dim_inner_;
-  Sparsity<nnz_subdiag, dim_outer, dim_inner_> subdiag;
-  Sparsity<nnz_diag, dim_outer, dim_outer> diag;
+  SparsityStatic<nnz_subdiag, dim_outer, dim_inner_> subdiag;
+  SparsityStatic<nnz_diag, dim_outer, dim_outer> diag;
   PermutationStatic<dim_outer> permutation = PermutationIdentity{};
 };
 
 template <class Subdiag, class Diag, class PermutationIn = PermutationIdentity>
 SparsityToFactorizeOuter(Subdiag, Diag, PermutationIn = PermutationIdentity{})
-    -> SparsityToFactorizeOuter<
-        ctad_t<Sparsity, Subdiag>::numCols(), ctad_t<Sparsity, Diag>::numRows(),
-        ctad_t<Sparsity, Subdiag>::nnz(), ctad_t<Sparsity, Diag>::nnz()>;
+    -> SparsityToFactorizeOuter<ctad_t<SparsityStatic, Subdiag>::numCols(),
+                                ctad_t<SparsityStatic, Diag>::numRows(),
+                                ctad_t<SparsityStatic, Subdiag>::nnz(),
+                                ctad_t<SparsityStatic, Diag>::nnz()>;
 
 template <std::size_t dim_inner, std::size_t dim_outer>
 constexpr auto makeEmptySparsityToFactorizeOuter() {
-  return SparsityToFactorizeOuter{makeEmptySparsity<dim_outer, dim_inner>(),
-                                  makeEmptySparsity<dim_outer, dim_outer>()};
+  return SparsityToFactorizeOuter{
+      makeEmptySparsityStatic<dim_outer, dim_inner>(),
+      makeEmptySparsityStatic<dim_outer, dim_outer>()};
 }
 
 }  // namespace ctldl

--- a/ctldl/factor_data/sparsity_to_factorize_start.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_start.hpp
@@ -33,9 +33,9 @@ struct SparsityToFactorizeStart {
   static constexpr auto dim = dim_start;
   static constexpr auto dim_next = dim_next_;
   static constexpr auto dim_outer = dim_outer_;
-  Sparsity<nnz_start, dim_start, dim_start> diag;
-  Sparsity<nnz_next, dim_next_, dim_start> next;
-  Sparsity<nnz_outer, dim_outer_, dim_start> outer;
+  SparsityStatic<nnz_start, dim_start, dim_start> diag;
+  SparsityStatic<nnz_next, dim_next_, dim_start> next;
+  SparsityStatic<nnz_outer, dim_outer_, dim_start> outer;
   PermutationStatic<dim_start> permutation = PermutationIdentity{};
 };
 
@@ -43,16 +43,19 @@ template <class Diag, class Next, class Outer,
           class PermutationIn = PermutationIdentity>
 SparsityToFactorizeStart(Diag, Next, Outer,
                          PermutationIn = PermutationIdentity{})
-    -> SparsityToFactorizeStart<
-        ctad_t<Sparsity, Diag>::numRows(), ctad_t<Sparsity, Next>::numRows(),
-        ctad_t<Sparsity, Outer>::numRows(), ctad_t<Sparsity, Diag>::nnz(),
-        ctad_t<Sparsity, Next>::nnz(), ctad_t<Sparsity, Outer>::nnz()>;
+    -> SparsityToFactorizeStart<ctad_t<SparsityStatic, Diag>::numRows(),
+                                ctad_t<SparsityStatic, Next>::numRows(),
+                                ctad_t<SparsityStatic, Outer>::numRows(),
+                                ctad_t<SparsityStatic, Diag>::nnz(),
+                                ctad_t<SparsityStatic, Next>::nnz(),
+                                ctad_t<SparsityStatic, Outer>::nnz()>;
 
 template <std::size_t dim_start, std::size_t dim_next, std::size_t dim_outer>
 constexpr auto makeEmptySparsityToFactorizeStart() {
-  return SparsityToFactorizeStart{makeEmptySparsity<dim_start, dim_start>(),
-                                  makeEmptySparsity<dim_next, dim_start>(),
-                                  makeEmptySparsity<dim_outer, dim_start>()};
+  return SparsityToFactorizeStart{
+      makeEmptySparsityStatic<dim_start, dim_start>(),
+      makeEmptySparsityStatic<dim_next, dim_start>(),
+      makeEmptySparsityStatic<dim_outer, dim_start>()};
 }
 
 }  // namespace ctldl

--- a/ctldl/factor_data/sparsity_to_factorize_tridiagonal.hpp
+++ b/ctldl/factor_data/sparsity_to_factorize_tridiagonal.hpp
@@ -29,8 +29,8 @@ template <std::size_t dim_, std::size_t nnz_diagonal,
           std::size_t nnz_subdiagonal>
 struct SparsityToFactorizeTridiagonal {
   static constexpr auto dim = dim_;
-  Sparsity<nnz_diagonal, dim, dim> diag;
-  Sparsity<nnz_subdiagonal, dim, dim> subdiag;
+  SparsityStatic<nnz_diagonal, dim, dim> diag;
+  SparsityStatic<nnz_subdiagonal, dim, dim> subdiag;
   PermutationStatic<dim> permutation = PermutationIdentity{};
 };
 
@@ -38,8 +38,9 @@ template <class SparsityDiag, class SparsitySubdiag,
           class PermutationIn = PermutationIdentity>
 SparsityToFactorizeTridiagonal(SparsityDiag, SparsitySubdiag,
                                PermutationIn = PermutationIdentity{})
-    -> SparsityToFactorizeTridiagonal<ctad_t<Sparsity, SparsityDiag>::numRows(),
-                                      ctad_t<Sparsity, SparsityDiag>::nnz(),
-                                      ctad_t<Sparsity, SparsitySubdiag>::nnz()>;
+    -> SparsityToFactorizeTridiagonal<
+        ctad_t<SparsityStatic, SparsityDiag>::numRows(),
+        ctad_t<SparsityStatic, SparsityDiag>::nnz(),
+        ctad_t<SparsityStatic, SparsitySubdiag>::nnz()>;
 
 }  // namespace ctldl

--- a/ctldl/factorize/factor_initialization.hpp
+++ b/ctldl/factorize/factor_initialization.hpp
@@ -11,7 +11,8 @@ namespace ctldl {
 
 template <std::size_t num_rows, std::size_t num_cols>
 struct FactorInitNone {
-  static constexpr auto sparsity = makeEmptySparsity<num_rows, num_cols>();
+  static constexpr auto sparsity =
+      makeEmptySparsityStatic<num_rows, num_cols>();
 };
 
 template <std::size_t entry_index, class Init, class FactorData>

--- a/ctldl/factorize/factorize_entry_wise.hpp
+++ b/ctldl/factorize/factorize_entry_wise.hpp
@@ -217,11 +217,12 @@ void factorizeEntryWise(const FactorData11& factor11, const Init21& init21,
                         const Regularization auto& regularization) {
   static_assert(isChordalBlocked(FactorData11::sparsity, FactorData21::sparsity,
                                  FactorData22::sparsity));
-  static_assert(isSparsitySubsetLowerTriangle<Init22::sparsity>(
-      FactorData22::sparsity, FactorData22::permutation));
-  static_assert(isSparsitySubset(Init21::sparsity, FactorData21::sparsity,
-                                 FactorData21::permutation_row,
-                                 FactorData21::permutation_col));
+  static_assert(isSparsitySubsetLowerTriangle(SparsityStatic(Init22::sparsity),
+                                              FactorData22::sparsity,
+                                              FactorData22::permutation));
+  static_assert(isSparsitySubset(
+      SparsityStatic(Init21::sparsity), FactorData21::sparsity,
+      FactorData21::permutation_row, FactorData21::permutation_col));
   constexpr auto num_rows = std::size_t{FactorData22::sparsity.numRows()};
   factorizeEntryWiseSubdiagonalImpl(factor21, init21, factor11,
                                     std::make_index_sequence<num_rows>());

--- a/ctldl/factorize/factorize_up_looking.hpp
+++ b/ctldl/factorize/factorize_up_looking.hpp
@@ -237,11 +237,12 @@ void factorizeUpLooking(const FactorData11& factor11, const Init21& init21,
                         const Regularization auto& regularization) {
   static_assert(isChordalBlocked(FactorData11::sparsity, FactorData21::sparsity,
                                  FactorData22::sparsity));
-  static_assert(isSparsitySubsetLowerTriangle<Init22::sparsity>(
-      FactorData22::sparsity, FactorData22::permutation));
-  static_assert(isSparsitySubset(Init21::sparsity, FactorData21::sparsity,
-                                 FactorData21::permutation_row,
-                                 FactorData21::permutation_col));
+  static_assert(isSparsitySubsetLowerTriangle(SparsityStatic(Init22::sparsity),
+                                              FactorData22::sparsity,
+                                              FactorData22::permutation));
+  static_assert(isSparsitySubset(
+      SparsityStatic(Init21::sparsity), FactorData21::sparsity,
+      FactorData21::permutation_row, FactorData21::permutation_col));
   constexpr auto num_rows = std::size_t{FactorData22::sparsity.numRows()};
   factorizeUpLookingImpl(factor11, init21, init22, factor21, factor22,
                          regularization, std::make_index_sequence<num_rows>());

--- a/ctldl/fileio/mtx_file_read_repeating_block_tridiagonal_arrowhead_linked.hpp
+++ b/ctldl/fileio/mtx_file_read_repeating_block_tridiagonal_arrowhead_linked.hpp
@@ -82,7 +82,7 @@ void mtxAddEntryLink(const MtxEntry entry, Matrix& matrix) {
 
 template <auto sparsity_in>
 struct MtxInputMatrix {
-  static constexpr auto sparsity = SparsityCSR(sparsity_in);
+  static constexpr auto sparsity = SparsityStaticCSR(sparsity_in);
   std::array<double, sparsity.nnz()> values = {};
   double valueAt(const std::size_t entry_index) const {
     return values[entry_index];

--- a/ctldl/matrix/empty_matrix_input.hpp
+++ b/ctldl/matrix/empty_matrix_input.hpp
@@ -9,7 +9,8 @@ namespace ctldl {
 
 template <std::size_t num_rows, std::size_t num_cols>
 struct EmptyMatrixInput {
-  static constexpr auto sparsity = makeEmptySparsityCSR<num_rows, num_cols>();
+  static constexpr auto sparsity =
+      makeEmptySparsityStaticCSR<num_rows, num_cols>();
 
   constexpr EmptyMatrixInput() = default;
 

--- a/ctldl/permutation/permutation.hpp
+++ b/ctldl/permutation/permutation.hpp
@@ -49,6 +49,13 @@ class PermutationDynamic {
       const std::span<const std::size_t> indices)
       : m_indices(indices.begin(), indices.end()) {}
 
+  constexpr explicit PermutationDynamic(const std::size_t dim)
+      : m_indices([dim] {
+          std::vector<std::size_t> permutation(dim);
+          std::iota(permutation.begin(), permutation.end(), std::size_t{0});
+          return permutation;
+        }()) {}
+
   constexpr const std::vector<std::size_t>& indices() const {
     return m_indices;
   }

--- a/ctldl/sparsity/get_entries_csr.hpp
+++ b/ctldl/sparsity/get_entries_csr.hpp
@@ -1,48 +1,67 @@
 #pragma once
 
 #include <ctldl/sparsity/entry.hpp>
+#include <ctldl/sparsity/sparsity.hpp>
+#include <ctldl/utility/contracts.hpp>
 #include <ctldl/utility/fix_init_if_zero_length_array.hpp>
 
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <numeric>
+#include <vector>
 
 namespace ctldl {
 
-template <class Sparsity>
-constexpr auto getRowCounts(const Sparsity& sparsity) {
-  std::array<std::size_t, Sparsity::numRows()> row_counts;
-  fixInitIfZeroLengthArray(row_counts);
-  row_counts.fill(0);
+constexpr auto getRowCounts(const SparsityView sparsity) {
+  std::vector<std::size_t> row_counts(sparsity.numRows(), 0);
   for (const auto entry : sparsity.entries()) {
     row_counts[entry.row_index] += 1;
   }
   return row_counts;
 }
 
-template <std::size_t dim>
 constexpr auto getRowBeginIndices(
-    const std::array<std::size_t, dim> row_counts) {
-  std::array<std::size_t, dim + 1> row_begin_indices;
+    const std::span<const std::size_t> row_counts) {
+  pre(row_counts.size() < std::numeric_limits<std::size_t>::max());
+
+  std::vector<std::size_t> row_begin_indices(row_counts.size() + 1);
+  contract_assert(!row_begin_indices.empty());
   row_begin_indices[0] = 0;
-  std::partial_sum(row_counts.cbegin(), row_counts.cend(),
+  std::partial_sum(row_counts.begin(), row_counts.end(),
                    row_begin_indices.begin() + 1);
   return row_begin_indices;
 }
 
-template <class Sparsity>
-constexpr auto getEntriesCSR(const Sparsity& sparsity) {
+struct EntriesCSR {
+  std::vector<Entry> entries;
+  std::vector<std::size_t> row_begin_indices;
+};
+
+constexpr auto getEntriesCSR(const SparsityView sparsity) {
   const auto row_counts = getRowCounts(sparsity);
   const auto row_begin_indices = getRowBeginIndices(row_counts);
 
-  std::array<Entry, Sparsity::nnz()> entries;
-  fixInitIfZeroLengthArray(entries);
+  std::vector<Entry> entries(sparsity.nnz());
   auto row_insert_indices = row_begin_indices;
   for (const auto entry : sparsity.entries()) {
     entries[row_insert_indices[entry.row_index]] =
         Entry{entry.row_index, entry.col_index};
     row_insert_indices[entry.row_index] += 1;
   }
+  return EntriesCSR{entries, row_begin_indices};
+}
+
+template <class Sparsity>
+constexpr auto getEntriesStaticCSR(const Sparsity& sparsity) {
+  std::array<Entry, Sparsity::nnz()> entries;
+  std::array<std::size_t, Sparsity::numRows() + 1> row_begin_indices;
+  fixInitIfZeroLengthArray(entries);
+  fixInitIfZeroLengthArray(row_begin_indices);
+
+  const auto entries_csr = getEntriesCSR(sparsity);
+  std::ranges::copy(entries_csr.entries, entries.begin());
+  std::ranges::copy(entries_csr.row_begin_indices, row_begin_indices.begin());
   return std::pair{entries, row_begin_indices};
 }
 

--- a/ctldl/sparsity/is_lower_triangle.hpp
+++ b/ctldl/sparsity/is_lower_triangle.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <ctldl/sparsity/sparsity.hpp>
+
 namespace ctldl {
 
-template <class Sparsity>
-constexpr bool isLowerTriangle(const Sparsity& sparsity) {
+constexpr bool isLowerTriangle(const SparsityView sparsity) {
   for (const auto& entry : sparsity.entries()) {
     if (entry.row_index <= entry.col_index) {
       return false;

--- a/ctldl/sparsity/is_sparsity_equal.hpp
+++ b/ctldl/sparsity/is_sparsity_equal.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <ctldl/sparsity/is_sparsity_subset.hpp>
+#include <ctldl/sparsity/sparsity.hpp>
 
 namespace ctldl {
 
-template <class SparsityLhs, class SparsityRhs>
-constexpr bool isSparsityEqual(
-    const SparsityLhs& sparsity_lhs, const SparsityRhs& sparsity_rhs) {
+constexpr bool isSparsityEqual(const SparsityView sparsity_lhs,
+                               const SparsityView sparsity_rhs) {
   return isSparsitySubset(sparsity_lhs, sparsity_rhs) &&
          isSparsitySubset(sparsity_rhs, sparsity_lhs);
 }

--- a/ctldl/sparsity/is_square.hpp
+++ b/ctldl/sparsity/is_square.hpp
@@ -1,15 +1,11 @@
 #pragma once
 
+#include <ctldl/sparsity/sparsity.hpp>
+
 namespace ctldl {
 
-template <class Sparsity>
-constexpr bool isSquare() {
-  return Sparsity::numRows() == Sparsity::numCols();
-}
-
-template <class Sparsity>
-constexpr bool isSquare(const Sparsity& /*sparsity*/) {
-  return isSquare<Sparsity>();
+constexpr bool isSquare(const SparsityView sparsity) {
+  return sparsity.numRows() == sparsity.numCols();
 }
 
 }  // namespace ctldl

--- a/ctldl/sparsity/sort_entries_row_major_sorted.hpp
+++ b/ctldl/sparsity/sort_entries_row_major_sorted.hpp
@@ -3,13 +3,11 @@
 #include <ctldl/sparsity/entry.hpp>
 
 #include <algorithm>
-#include <array>
-#include <cstddef>
+#include <span>
 
 namespace ctldl {
 
-template <std::size_t dim>
-constexpr void sortEntriesRowMajorSorted(std::array<Entry, dim>& entries) {
+constexpr void sortEntriesRowMajorSorted(const std::span<Entry> entries) {
   const auto row_major_sorted_order = [](const Entry lhs, const Entry rhs) {
     return lhs.row_index < rhs.row_index ||
            (lhs.row_index == rhs.row_index && lhs.col_index < rhs.col_index);

--- a/ctldl/sparsity/sparsity.hpp
+++ b/ctldl/sparsity/sparsity.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ctldl/sparsity/entry.hpp>
+#include <ctldl/utility/contracts.hpp>
 #include <ctldl/utility/fix_init_if_zero_length_array.hpp>
 
 #include <algorithm>
@@ -9,11 +10,13 @@
 #include <concepts>
 #include <cstddef>
 #include <ranges>
+#include <vector>
+#include <span>
 
 namespace ctldl {
 
 template <std::size_t nnz_, std::size_t num_rows_, std::size_t num_cols_>
-struct Sparsity {
+struct SparsityStatic {
   static constexpr std::size_t nnz() { return nnz_; }
   static constexpr std::size_t numRows() { return num_rows_; }
   static constexpr std::size_t numCols() { return num_cols_; }
@@ -24,7 +27,8 @@ struct Sparsity {
     return m_entries_do_not_touch;
   }
 
-  constexpr explicit Sparsity(std::ranges::input_range auto&& entries_init) {
+  constexpr explicit SparsityStatic(
+      std::ranges::input_range auto&& entries_init) {
     fixInitIfZeroLengthArray(m_entries_do_not_touch);
     std::ranges::transform(entries_init, std::begin(m_entries_do_not_touch),
                            [](const auto& entry) {
@@ -39,42 +43,135 @@ struct Sparsity {
     requires(std::ranges::input_range<decltype(SparsityIn::entries())> &&
              std::convertible_to<decltype(SparsityIn::numRows()), std::size_t> &&
              std::convertible_to<decltype(SparsityIn::numCols()), std::size_t>)
-  constexpr Sparsity(const SparsityIn& sparsity_in)
-      : Sparsity(sparsity_in.entries()) {}
+  constexpr SparsityStatic(const SparsityIn& sparsity_in)
+      : SparsityStatic(sparsity_in.entries()) {}
 };
 
 template <class SparsityIn>
-Sparsity(const SparsityIn& sparsity_in)
-    -> Sparsity<std::tuple_size_v<decltype(SparsityIn::entries())>,
-                SparsityIn::numRows(), SparsityIn::numCols()>;
+SparsityStatic(const SparsityIn& sparsity_in)
+    -> SparsityStatic<std::tuple_size_v<decltype(SparsityIn::entries())>,
+                      SparsityIn::numRows(), SparsityIn::numCols()>;
 
 template <std::size_t num_rows, std::size_t num_cols, class Entries>
-constexpr auto makeSparsity(const Entries& entries) {
+constexpr auto makeSparsityStatic(const Entries& entries) {
   using std::size;
   constexpr auto nnz = std::size_t{size(Entries{})};
-  return Sparsity<nnz, num_rows, num_cols>(entries);
+  return SparsityStatic<nnz, num_rows, num_cols>(entries);
 }
 
 template <std::size_t num_rows, std::size_t num_cols, class Entry,
           std::size_t nnz>
-constexpr auto makeSparsity(const Entry (&entries)[nnz]) {
-  return Sparsity<nnz, num_rows, num_cols>(entries);
+constexpr auto makeSparsityStatic(const Entry (&entries)[nnz]) {
+  return SparsityStatic<nnz, num_rows, num_cols>(entries);
 }
 
 template <std::size_t num_rows, std::size_t num_cols, std::size_t nnz>
-constexpr auto makeSparsity(const Entry (&entries)[nnz]) {
-  return Sparsity<nnz, num_rows, num_cols>(entries);
+constexpr auto makeSparsityStatic(const Entry (&entries)[nnz]) {
+  return SparsityStatic<nnz, num_rows, num_cols>(entries);
 }
 
 template <class SparsityIn>
-constexpr auto makeSparsity(const SparsityIn& sparsity) {
-  return makeSparsity<SparsityIn::numRows(), SparsityIn::numCols()>(
+constexpr auto makeSparsityStatic(const SparsityIn& sparsity) {
+  return makeSparsityStatic<SparsityIn::numRows(), SparsityIn::numCols()>(
       sparsity.entries());
 }
 
 template <std::size_t num_rows, std::size_t num_cols>
-constexpr auto makeEmptySparsity() {
-  return makeSparsity<num_rows, num_cols>(std::array<Entry, 0>{});
+constexpr auto makeEmptySparsityStatic() {
+  return makeSparsityStatic<num_rows, num_cols>(std::array<Entry, 0>{});
 }
+
+class SparsityDynamic {
+ private:
+  static constexpr std::vector<Entry> makeEntries(
+      std::ranges::input_range auto&& entries_init) {
+    const auto entries_transformed =
+        std::views::transform(entries_init, [](const auto& entry) {
+          return Entry{entry.row_index, entry.col_index};
+        });
+    return std::vector<Entry>(entries_transformed.begin(),
+                              entries_transformed.end());
+  }
+
+  std::vector<Entry> m_entries;
+  std::size_t m_num_rows;
+  std::size_t m_num_cols;
+
+ public:
+  constexpr const std::vector<Entry>& entries() const {
+    return m_entries;
+  }
+
+  constexpr std::size_t numRows() const {
+    return m_num_rows;
+  }
+
+  constexpr std::size_t numCols() const {
+    return m_num_cols;
+  }
+
+  constexpr std::size_t nnz() const {
+    return m_entries.size();
+  }
+
+  constexpr explicit SparsityDynamic(
+      const std::size_t num_rows_, const std::size_t num_cols_,
+      std::ranges::input_range auto&& entries_init)
+      : m_entries(makeEntries(entries_init)),
+        m_num_rows(num_rows_),
+        m_num_cols(num_cols_) {
+    pre(std::ranges::all_of(
+        entries_init, [num_rows_, num_cols_](const auto entry) {
+          return entry.row_index < num_rows_ && entry.col_index < num_cols_;
+        }));
+  }
+
+  template <std::size_t nnz_, std::size_t num_rows_, std::size_t num_cols_>
+  explicit constexpr SparsityDynamic(
+      const SparsityStatic<nnz_, num_rows_, num_cols_>& sparsity)
+      : SparsityDynamic(sparsity.numRows(), sparsity.numCols(),
+                        sparsity.entries()) {}
+};
+
+constexpr auto makeEmptySparsityDynamic(const std::size_t num_rows,
+                                        const std::size_t num_cols) {
+  return SparsityDynamic(num_rows, num_cols, std::vector<Entry>{});
+}
+
+class SparsityView {
+public:
+  constexpr SparsityView(const SparsityDynamic& sparsity)
+      : m_entries(sparsity.entries()),
+        m_num_rows(sparsity.numRows()),
+        m_num_cols(sparsity.numCols()) {}
+
+  template <std::size_t nnz_, std::size_t num_rows_, std::size_t num_cols_>
+  constexpr SparsityView(
+      const SparsityStatic<nnz_, num_rows_, num_cols_>& sparsity)
+      : m_entries(sparsity.entries()),
+        m_num_rows(sparsity.numRows()),
+        m_num_cols(sparsity.numCols()) {}
+
+  constexpr const std::span<const Entry> entries() const {
+    return m_entries;
+  }
+
+  constexpr std::size_t numRows() const {
+    return m_num_rows;
+  }
+
+  constexpr std::size_t numCols() const {
+    return m_num_cols;
+  }
+
+  constexpr std::size_t nnz() const {
+    return m_entries.size();
+  }
+
+private:
+  std::span<const Entry> m_entries;
+  std::size_t m_num_rows;
+  std::size_t m_num_cols;
+};
 
 }  // namespace ctldl

--- a/ctldl/sparsity/sparsity_csr.hpp
+++ b/ctldl/sparsity/sparsity_csr.hpp
@@ -11,11 +11,11 @@
 namespace ctldl {
 
 template <std::size_t nnz, std::size_t num_rows, std::size_t num_cols>
-struct SparsityCSR : public Sparsity<nnz, num_rows, num_cols> {
+struct SparsityStaticCSR : public SparsityStatic<nnz, num_rows, num_cols> {
  private:
-  using Base = Sparsity<nnz, num_rows, num_cols>;
+  using Base = SparsityStatic<nnz, num_rows, num_cols>;
 
-  constexpr explicit SparsityCSR(
+  constexpr explicit SparsityStaticCSR(
       std::pair<std::array<Entry, nnz>, std::array<std::size_t, num_rows + 1>>
           helper)
       : Base(helper.first), m_row_begin_indices_do_not_touch(helper.second) {}
@@ -29,8 +29,8 @@ struct SparsityCSR : public Sparsity<nnz, num_rows, num_cols> {
   }
 
   template <class SparsityIn>
-  constexpr explicit SparsityCSR(const SparsityIn& sparsity)
-      : SparsityCSR(getEntriesCSR(sparsity)) {}
+  constexpr explicit SparsityStaticCSR(const SparsityIn& sparsity)
+      : SparsityStaticCSR(getEntriesStaticCSR(sparsity)) {}
 
   constexpr auto rowView(const std::size_t i) const {
     return std::span{Base::entries().data() + rowBeginIndices()[i],
@@ -54,34 +54,122 @@ struct SparsityCSR : public Sparsity<nnz, num_rows, num_cols> {
 };
 
 template <class SparsityIn>
-SparsityCSR(const SparsityIn&)
-    -> SparsityCSR<SparsityIn::nnz(), SparsityIn::numRows(),
-                   SparsityIn::numCols()>;
+SparsityStaticCSR(const SparsityIn&)
+    -> SparsityStaticCSR<SparsityIn::nnz(), SparsityIn::numRows(),
+                         SparsityIn::numCols()>;
 
 template <class SparsityIn>
-constexpr auto makeSparsityCSR(const SparsityIn& sparsity) {
-  return SparsityCSR{makeSparsity(sparsity)};
+constexpr auto makeSparsityStaticCSR(const SparsityIn& sparsity) {
+  return SparsityStaticCSR{makeSparsityStatic(sparsity)};
 }
 
 template <std::size_t num_rows, std::size_t num_cols, class Entries>
-constexpr auto makeSparsityCSR(const Entries& entries) {
-  return SparsityCSR{makeSparsity<num_rows, num_cols>(entries)};
+constexpr auto makeSparsityStaticCSR(const Entries& entries) {
+  return SparsityStaticCSR{makeSparsityStatic<num_rows, num_cols>(entries)};
 }
 
 template <std::size_t num_rows, std::size_t num_cols, class Entry,
           std::size_t nnz>
-constexpr auto makeSparsityCSR(const Entry (&entries)[nnz]) {
-  return SparsityCSR{makeSparsity<num_rows, num_cols>(entries)};
+constexpr auto makeSparsityStaticCSR(const Entry (&entries)[nnz]) {
+  return SparsityStaticCSR{makeSparsityStatic<num_rows, num_cols>(entries)};
 }
 
 template <std::size_t num_rows, std::size_t num_cols, std::size_t nnz>
-constexpr auto makeSparsityCSR(const Entry (&entries)[nnz]) {
-  return SparsityCSR{makeSparsity<num_rows, num_cols>(entries)};
+constexpr auto makeSparsityStaticCSR(const Entry (&entries)[nnz]) {
+  return SparsityStaticCSR{makeSparsityStatic<num_rows, num_cols>(entries)};
 }
 
 template <std::size_t num_rows, std::size_t num_cols>
-constexpr auto makeEmptySparsityCSR() {
-  return SparsityCSR{makeEmptySparsity<num_rows, num_cols>()};
+constexpr auto makeEmptySparsityStaticCSR() {
+  return SparsityStaticCSR{makeEmptySparsityStatic<num_rows, num_cols>()};
 }
+
+class SparsityDynamicCSR : public SparsityDynamic {
+ private:
+  std::vector<std::size_t> m_row_begin_indices = {0};
+
+  constexpr explicit SparsityDynamicCSR(const std::size_t num_rows,
+                                        const std::size_t num_cols,
+                                        const EntriesCSR& entries_csr)
+      : SparsityDynamic(num_rows, num_cols, entries_csr.entries),
+        m_row_begin_indices(entries_csr.row_begin_indices) {}
+
+ public:
+  constexpr explicit SparsityDynamicCSR(const SparsityDynamic& sparsity)
+      : SparsityDynamicCSR(sparsity.numRows(), sparsity.numCols(),
+                           getEntriesCSR(sparsity)) {}
+
+  template <std::size_t nnz, std::size_t num_rows_, std::size_t num_cols_>
+  constexpr explicit SparsityDynamicCSR(
+      const SparsityStaticCSR<nnz, num_rows_, num_cols_>& sparsity)
+      : SparsityDynamic(sparsity.numRows(), sparsity.numCols(),
+                        sparsity.entries()),
+        m_row_begin_indices(sparsity.rowBeginIndices()) {}
+
+  constexpr const std::vector<std::size_t>& rowBeginIndices() const {
+    return m_row_begin_indices;
+  }
+
+  constexpr auto rowView(const std::size_t i) const {
+    return std::span{entries().data() + m_row_begin_indices[i],
+                     entries().data() + m_row_begin_indices[i + 1]};
+  }
+
+  constexpr auto find(const std::size_t i, const std::size_t j) const {
+    const auto row = rowView(i);
+    return std::find_if(std::cbegin(row), std::cend(row),
+                        [j](const auto entry) { return entry.col_index == j; });
+  }
+
+  constexpr bool isNonZero(const std::size_t i, const std::size_t j) const {
+    return find(i, j) != std::cend(rowView(i));
+  }
+
+  constexpr auto entryIndex(const std::size_t i, const std::size_t j) const {
+    assert(isNonZero(i, j));
+    return static_cast<std::size_t>(find(i, j) - std::cbegin(rowView(0)));
+  }
+};
+
+constexpr auto makeEmptySparsityDynamicCSR(const std::size_t num_rows,
+                                           const std::size_t num_cols) {
+  return SparsityDynamicCSR(makeEmptySparsityDynamic(num_rows, num_cols));
+}
+
+class SparsityViewCSR : public SparsityView {
+ private:
+  std::span<const std::size_t> m_row_begin_indices;
+
+ public:
+  constexpr SparsityViewCSR(const SparsityDynamicCSR& sparsity)
+      : SparsityView(sparsity),
+        m_row_begin_indices(sparsity.rowBeginIndices()) {}
+
+  template <std::size_t nnz, std::size_t num_rows_, std::size_t num_cols_>
+  constexpr SparsityViewCSR(
+      const SparsityStaticCSR<nnz, num_rows_, num_cols_>& sparsity)
+      : SparsityView(sparsity),
+        m_row_begin_indices(sparsity.rowBeginIndices()) {}
+
+  constexpr auto rowView(const std::size_t i) const {
+    return std::span{entries().data() + m_row_begin_indices[i],
+                     entries().data() + m_row_begin_indices[i + 1]};
+  }
+
+  constexpr auto find(const std::size_t i, const std::size_t j) const {
+    const auto row = rowView(i);
+    return std::find_if(std::cbegin(row), std::cend(row),
+                        [j](const auto entry) { return entry.col_index == j; });
+  }
+
+  constexpr bool isNonZero(const std::size_t i, const std::size_t j) const {
+    return find(i, j) != std::cend(rowView(i));
+  }
+
+  constexpr auto entryIndex(const std::size_t i, const std::size_t j) const {
+    assert(isNonZero(i, j));
+    return static_cast<std::size_t>(find(i, j) - std::cbegin(rowView(0)));
+  }
+};
 
 }  // namespace ctldl

--- a/ctldl/sparsity/sparsity_lower_triangle.hpp
+++ b/ctldl/sparsity/sparsity_lower_triangle.hpp
@@ -5,15 +5,16 @@
 #include <ctldl/sparsity/entry.hpp>
 #include <ctldl/sparsity/is_square.hpp>
 #include <ctldl/utility/fix_init_if_zero_length_array.hpp>
+#include <ctldl/utility/contracts.hpp>
 
 #include <array>
 #include <cstddef>
+#include <vector>
 
 namespace ctldl {
 
-template <class Sparsity>
-constexpr auto getNnzLowerTriangle(const Sparsity& sparsity) {
-  static_assert(isSquare<Sparsity>());
+constexpr auto getNnzLowerTriangle(const SparsityView sparsity) {
+  pre(isSquare(sparsity));
   std::size_t nnz = 0;
   for (const auto entry : sparsity.entries()) {
     nnz += (entry.row_index > entry.col_index);
@@ -21,33 +22,40 @@ constexpr auto getNnzLowerTriangle(const Sparsity& sparsity) {
   return nnz;
 }
 
-template <std::size_t nnz, class Sparsity>
-constexpr auto getEntriesLowerTriangle(const Sparsity& sparsity,
+constexpr auto getEntriesLowerTriangle(const SparsityView sparsity,
                                        const PermutationView permutation) {
-  static_assert(isSquare<Sparsity>());
-  const auto inverse_permutation = invertPermutation(permutation);
+  pre(isSquare(sparsity));
 
-  std::array<Entry, nnz> entries;
-  fixInitIfZeroLengthArray(entries);
-  std::size_t entry_index = 0;
-  for (const auto entry : sparsity.entries()) {
-    if (entry.row_index <= entry.col_index) {
-      continue;
-    }
-    entries[entry_index] =
-        permutedEntryLowerTriangle(entry, inverse_permutation);
-    entry_index += 1;
-  }
-  return entries;
+  const auto inverse_permutation = invertPermutation(permutation);
+  const auto is_lower_triangle = [](const Entry entry) {
+    return entry.row_index > entry.col_index;
+  };
+  const auto permute_entry = [&inverse_permutation](const Entry entry) {
+    return permutedEntryLowerTriangle(entry, inverse_permutation);
+  };
+  auto entries_permuted_lower_triangle = sparsity.entries() |
+                                         std::views::filter(is_lower_triangle) |
+                                         std::views::transform(permute_entry);
+  return std::vector<Entry>(entries_permuted_lower_triangle.begin(),
+                            entries_permuted_lower_triangle.end());
 }
 
-template <auto sparsity>
-constexpr auto getSparsityLowerTriangle(const PermutationView permutation) {
-  static_assert(isSquare(sparsity));
-  constexpr auto dim = std::size_t{sparsity.numRows()};
+constexpr auto getSparsityDynamicLowerTriangle(
+    const SparsityView sparsity, const PermutationView permutation) {
+  pre(isSquare(sparsity));
+  return SparsityDynamic(sparsity.numRows(), sparsity.numCols(),
+                         getEntriesLowerTriangle(sparsity, permutation));
+}
+
+template <SparsityStatic sparsity>
+constexpr auto getSparsityStaticLowerTriangle(
+    const PermutationView permutation) {
   constexpr auto nnz = getNnzLowerTriangle(sparsity);
-  const auto entries = getEntriesLowerTriangle<nnz>(sparsity, permutation);
-  return Sparsity<nnz, dim, dim>(entries);
+  std::array<Entry, nnz> entries;
+  fixInitIfZeroLengthArray(entries);
+  std::ranges::copy(getEntriesLowerTriangle(sparsity, permutation),
+                    entries.begin());
+  return SparsityStatic<nnz, sparsity.numRows(), sparsity.numCols()>(entries);
 }
 
 }  // namespace ctldl

--- a/ctldl/sparsity/sparsity_permuted.hpp
+++ b/ctldl/sparsity/sparsity_permuted.hpp
@@ -6,29 +6,48 @@
 #include <ctldl/sparsity/sparsity.hpp>
 
 #include <array>
-#include <cstddef>
+#include <ranges>
+#include <vector>
 
 namespace ctldl {
 
-template <class SparsityIn>
-constexpr auto getSparsityPermuted(const SparsityIn& sparsity,
-                                   const PermutationView permutation_row,
-                                   const PermutationView permutation_col) {
-  using std::size;
-  constexpr auto nnz = std::size_t{size(decltype(sparsity.entries()){})};
-
+constexpr auto getEntriesPermuted(const SparsityView sparsity,
+                                  const PermutationView permutation_row,
+                                  const PermutationView permutation_col) {
   const auto inverse_permutation_row = invertPermutation(permutation_row);
   const auto inverse_permutation_col = invertPermutation(permutation_col);
 
-  std::array<Entry, nnz> entries;
-  std::size_t entry_index = 0;
-  for (const auto entry : sparsity.entries()) {
-    entries[entry_index] = permutedEntry(entry, inverse_permutation_row,
-                                         inverse_permutation_col);
-    entry_index += 1;
-  }
+  const auto permute_entry = [&inverse_permutation_row,
+                              &inverse_permutation_col](const Entry entry) {
+    return permutedEntry(entry, inverse_permutation_row,
+                         inverse_permutation_col);
+  };
+  auto entries_permuted =
+      std::views::transform(sparsity.entries(), permute_entry);
+  return std::vector<Entry>(entries_permuted.begin(), entries_permuted.end());
+}
 
-  return Sparsity<nnz, SparsityIn::numRows(), SparsityIn::numCols()>(entries);
+constexpr auto getSparsityDynamicPermuted(
+    const SparsityView sparsity, const PermutationView permutation_row,
+    const PermutationView permutation_col) {
+  return SparsityDynamic(
+      sparsity.numRows(), sparsity.numCols(),
+      getEntriesPermuted(sparsity, permutation_row, permutation_col));
+}
+
+template <class SparsityIn>
+constexpr auto getSparsityStaticPermuted(
+    const SparsityIn& sparsity, const PermutationView permutation_row,
+    const PermutationView permutation_col) {
+  using std::size;
+  constexpr auto nnz = std::size_t{size(decltype(sparsity.entries()){})};
+
+  std::array<Entry, nnz> entries;
+  std::ranges::copy(
+      getEntriesPermuted(sparsity, permutation_row, permutation_col),
+      entries.begin());
+  return SparsityStatic<nnz, SparsityIn::numRows(), SparsityIn::numCols()>(
+      entries);
 }
 
 }  // namespace ctldl

--- a/ctldl/symbolic/add_row_elimination_tree.hpp
+++ b/ctldl/symbolic/add_row_elimination_tree.hpp
@@ -1,20 +1,21 @@
 #pragma once
 
+#include <ctldl/sparsity/sparsity_csr.hpp>
 #include <ctldl/symbolic/elimination_tree.hpp>
+#include <ctldl/utility/contracts.hpp>
 
-#include <array>
 #include <cstddef>
+#include <span>
 
 namespace ctldl {
 
-template <class Sparsity, std::size_t dim>
-constexpr void addRowEliminationTree(const Sparsity& sparsity,
+constexpr void addRowEliminationTree(const SparsityViewCSR sparsity,
                                      const std::size_t row_index,
-                                     EliminationTree<dim>& tree,
-                                     std::array<std::size_t, dim>& ancestors,
+                                     EliminationTree& tree,
+                                     const std::span<std::size_t> ancestors,
                                      const std::size_t row_offset = 0,
                                      const std::size_t col_offset = 0) {
-  static_assert(dim >= Sparsity::numRows());
+  pre(tree.parent.size() >= sparsity.numRows());
 
   const auto i = row_index + row_offset;
   for (const auto entry : sparsity.rowView(row_index)) {

--- a/ctldl/symbolic/compute_elimination_tree.hpp
+++ b/ctldl/symbolic/compute_elimination_tree.hpp
@@ -1,22 +1,23 @@
 #pragma once
 
+#include <ctldl/sparsity/sparsity_csr.hpp>
 #include <ctldl/sparsity/is_square.hpp>
 #include <ctldl/symbolic/add_row_elimination_tree.hpp>
 #include <ctldl/symbolic/elimination_tree.hpp>
+#include <ctldl/utility/contracts.hpp>
 
-#include <array>
 #include <cstddef>
 #include <numeric>
+#include <vector>
 
 namespace ctldl {
 
-template <class Sparsity>
-constexpr auto computeEliminationTree(const Sparsity& sparsity) {
-  static_assert(isSquare<Sparsity>());
-  constexpr auto dim = Sparsity::numRows();
+constexpr auto computeEliminationTree(const SparsityViewCSR sparsity) {
+  pre(isSquare(sparsity));
+  const auto dim = sparsity.numRows();
 
-  EliminationTree<dim> tree;
-  std::array<std::size_t, dim> ancestors;
+  EliminationTree tree(dim);
+  std::vector<std::size_t> ancestors(dim);
   std::iota(ancestors.begin(), ancestors.end(), 0);
   for (std::size_t i = 0; i < dim; ++i) {
     addRowEliminationTree(sparsity, i, tree, ancestors);

--- a/ctldl/symbolic/compute_elimination_tree_blocked.test.cpp
+++ b/ctldl/symbolic/compute_elimination_tree_blocked.test.cpp
@@ -3,23 +3,21 @@
 #include <ctldl/sparsity/sparsity.hpp>
 #include <ctldl/sparsity/sparsity_csr.hpp>
 
-#include "tests/utility/test_static.hpp"
-
 #include <boost/test/unit_test.hpp>
 
 namespace ctldl {
 namespace {
 
 BOOST_AUTO_TEST_CASE(ComputeEliminationTreeBlockedNos2Test) {
-  constexpr auto sparsity11 = makeEmptySparsityCSR<3, 3>();
+  constexpr auto sparsity11 = makeEmptySparsityStaticCSR<3, 3>();
   constexpr auto sparsity21 =
-      makeSparsityCSR<3, 3>({{0, 0}, {1, 1}, {1, 2}, {2, 1}, {2, 2}});
-  constexpr auto sparsity22 = makeEmptySparsityCSR<3, 3>();
-  constexpr auto tree =
+      makeSparsityStaticCSR<3, 3>({{0, 0}, {1, 1}, {1, 2}, {2, 1}, {2, 2}});
+  constexpr auto sparsity22 = makeEmptySparsityStaticCSR<3, 3>();
+  const auto tree =
       computeEliminationTreeBlocked(sparsity11, sparsity21, sparsity22);
 
-  constexpr auto tree_expected = [] {
-    EliminationTree<6> ret;
+  const auto tree_expected = [] {
+    EliminationTree ret(6);
     ret.parent[0] = 3;
     ret.parent[1] = 4;
     ret.parent[2] = 4;
@@ -27,8 +25,8 @@ BOOST_AUTO_TEST_CASE(ComputeEliminationTreeBlockedNos2Test) {
     return ret;
   }();
 
-  CTLDL_TEST_STATIC(tree.parent == tree_expected.parent,
-                    boost::test_tools::per_element());
+  BOOST_TEST(tree.parent == tree_expected.parent,
+             boost::test_tools::per_element());
 }
 
 }  // anonymous namespace

--- a/ctldl/symbolic/compute_elimination_tree_repeating.hpp
+++ b/ctldl/symbolic/compute_elimination_tree_repeating.hpp
@@ -1,44 +1,45 @@
 #pragma once
 
 #include <ctldl/sparsity/is_square.hpp>
+#include <ctldl/sparsity/sparsity_csr.hpp>
 #include <ctldl/symbolic/add_row_elimination_tree.hpp>
 #include <ctldl/symbolic/elimination_tree.hpp>
 #include <ctldl/symbolic/elimination_tree_subtree.hpp>
+#include <ctldl/utility/contracts.hpp>
 
 #include <algorithm>
-#include <array>
 #include <cstddef>
 #include <numeric>
 #include <ranges>
+#include <vector>
 
 
 namespace ctldl {
 
-template <class SparsityA, class SparsityB>
-constexpr auto computeEliminationTreeRepeating(const SparsityA& sparsity_A,
-                                               const SparsityB& sparsity_B) {
-  static_assert(isSquare<SparsityA>());
-  static_assert(isSquare<SparsityB>());
-  static_assert(SparsityA::numRows() == SparsityB::numRows());
-  constexpr auto dim = SparsityA::numRows();
+constexpr auto computeEliminationTreeRepeating(
+    const SparsityViewCSR sparsity_A, const SparsityViewCSR sparsity_B) {
+  pre(isSquare(sparsity_A));
+  pre(isSquare(sparsity_B));
+  pre(sparsity_A.numRows() == sparsity_B.numRows());
+  const auto dim = sparsity_A.numRows();
 
-  EliminationTree<2 * dim> tree;
-  EliminationTree<dim> tree_init;
+  EliminationTree tree(2 * dim);
+  EliminationTree tree_init(dim);
 
-  std::array<std::size_t, 2 * dim> ancestors;
+  std::vector<std::size_t> ancestors(2 * dim);
   std::iota(ancestors.begin(), ancestors.end(), 0);
 
   while (true) {
     const auto tree_init_previous = tree_init;
     for (std::size_t i = 0; i < dim; ++i) {
-      constexpr auto row_offset = dim;
-      constexpr auto col_offset = dim;
+      const auto row_offset = dim;
+      const auto col_offset = dim;
       addRowEliminationTree(sparsity_B, i, tree, ancestors, row_offset);
       addRowEliminationTree(sparsity_A, i, tree, ancestors, row_offset,
                             col_offset);
     }
 
-    tree_init = subtreeBack<dim>(tree);
+    tree_init = subtreeBack(tree, dim);
     if (tree_init == tree_init_previous) {
       break;
     }
@@ -46,9 +47,11 @@ constexpr auto computeEliminationTreeRepeating(const SparsityA& sparsity_A,
     setSubtreeFront(tree, tree_init);
     clearSubtreeBack(tree, dim);
     std::ranges::transform(
-        std::views::drop(ancestors, dim), ancestors.begin(),
-        [](const std::size_t ancestor) { return ancestor - dim; });
-    std::iota(ancestors.begin() + dim, ancestors.end(), dim);
+        std::views::drop(ancestors, static_cast<std::ptrdiff_t>(dim)),
+        ancestors.begin(),
+        [dim](const std::size_t ancestor) { return ancestor - dim; });
+    std::iota(ancestors.begin() + static_cast<std::ptrdiff_t>(dim),
+              ancestors.end(), dim);
   };
 
   return tree;

--- a/ctldl/symbolic/compute_elimination_tree_repeating.test.cpp
+++ b/ctldl/symbolic/compute_elimination_tree_repeating.test.cpp
@@ -10,13 +10,13 @@ namespace ctldl {
 namespace {
 
 BOOST_AUTO_TEST_CASE(ComputeEliminationTreeRepeatingExample0) {
-  constexpr auto sparsity_A = makeSparsityCSR<5, 5>({{3, 2}});
+  constexpr auto sparsity_A = makeSparsityStaticCSR<5, 5>({{3, 2}});
   constexpr auto sparsity_B =
-      makeSparsityCSR<5, 5>({{0, 3}, {2, 0}, {2, 1}, {2, 4}, {4, 4}});
-  constexpr auto tree = computeEliminationTreeRepeating(sparsity_A, sparsity_B);
+      makeSparsityStaticCSR<5, 5>({{0, 3}, {2, 0}, {2, 1}, {2, 4}, {4, 4}});
+  const auto tree = computeEliminationTreeRepeating(sparsity_A, sparsity_B);
 
-  constexpr auto tree_expected = [] {
-    EliminationTree<2 * 5> ret;
+  const auto tree_expected = [] {
+    EliminationTree ret(2 * 5);
     ret.parent[0] = 2;
     ret.parent[1] = 2 + 5;
     ret.parent[2] = 3;
@@ -28,18 +28,19 @@ BOOST_AUTO_TEST_CASE(ComputeEliminationTreeRepeatingExample0) {
     return ret;
   }();
 
-  CTLDL_TEST_STATIC(tree.parent == tree_expected.parent,
-                    boost::test_tools::per_element());
+  BOOST_TEST(tree.parent == tree_expected.parent,
+             boost::test_tools::per_element());
 }
 
 BOOST_AUTO_TEST_CASE(ComputeEliminationTreeRepeatingExample1) {
-  constexpr auto sparsity_A = makeSparsityCSR<7, 7>({{1, 0}, {2, 0}, {2, 1}});
-  constexpr auto sparsity_B = makeSparsityCSR<7, 7>(
+  constexpr auto sparsity_A =
+      makeSparsityStaticCSR<7, 7>({{1, 0}, {2, 0}, {2, 1}});
+  constexpr auto sparsity_B = makeSparsityStaticCSR<7, 7>(
       {{0, 5}, {0, 6}, {1, 3}, {1, 4}, {1, 5}, {2, 4}, {2, 6}});
-  constexpr auto tree = computeEliminationTreeRepeating(sparsity_A, sparsity_B);
+  const auto tree = computeEliminationTreeRepeating(sparsity_A, sparsity_B);
 
-  constexpr auto tree_expected = [] {
-    EliminationTree<2 * 7> ret;
+  const auto tree_expected = [] {
+    EliminationTree ret(2 * 7);
     ret.parent[0] = 1;
     ret.parent[1] = 2;
     ret.parent[3] = 1 + 7;
@@ -51,8 +52,8 @@ BOOST_AUTO_TEST_CASE(ComputeEliminationTreeRepeatingExample1) {
     return ret;
   }();
 
-  CTLDL_TEST_STATIC(tree.parent == tree_expected.parent,
-                    boost::test_tools::per_element());
+  BOOST_TEST(tree.parent == tree_expected.parent,
+             boost::test_tools::per_element());
 }
 
 }  // anonymous namespace

--- a/ctldl/symbolic/elimination_tree.hpp
+++ b/ctldl/symbolic/elimination_tree.hpp
@@ -1,24 +1,18 @@
 #pragma once
 
-#include <ctldl/utility/fix_init_if_zero_length_array.hpp>
-
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <cstddef>
 #include <limits>
+#include <vector>
 
 
 namespace ctldl {
 
-template <std::size_t dim>
 struct EliminationTree {
   static constexpr auto no_parent = std::numeric_limits<std::size_t>::max();
 
-  constexpr EliminationTree() {
-    fixInitIfZeroLengthArray(parent);
-    std::ranges::fill(parent, no_parent);
-  };
+  constexpr EliminationTree(const std::size_t dim) : parent(dim, no_parent) {};
 
   constexpr bool hasParent(const std::size_t node) const {
     return parent[node] != no_parent;
@@ -29,12 +23,11 @@ struct EliminationTree {
     return parent[node];
   }
 
-  std::array<std::size_t, dim> parent;
+  std::vector<std::size_t> parent;
 };
 
-template <std::size_t dim>
-constexpr bool operator==(const EliminationTree<dim>& lhs,
-                          const EliminationTree<dim>& rhs) {
+constexpr bool operator==(const EliminationTree& lhs,
+                          const EliminationTree& rhs) {
   return std::ranges::equal(lhs.parent, rhs.parent);
 }
 

--- a/ctldl/symbolic/elimination_tree_subtree.hpp
+++ b/ctldl/symbolic/elimination_tree_subtree.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ctldl/symbolic/elimination_tree.hpp>
+#include <ctldl/utility/contracts.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -8,29 +9,29 @@
 
 namespace ctldl {
 
-template <std::size_t dim_subtree, std::size_t dim>
-constexpr EliminationTree<dim_subtree> subtreeBack(
-    const EliminationTree<dim>& tree) {
-  static_assert(dim_subtree <= dim);
-  EliminationTree<dim_subtree> subtree;
-  std::transform(tree.parent.cend() - dim_subtree, tree.parent.cend(),
-                 subtree.parent.begin(), [&](const std::size_t node) {
+constexpr EliminationTree subtreeBack(
+    const EliminationTree& tree, const std::size_t dim_subtree) {
+  pre(dim_subtree <= tree.parent.size());
+  const auto dim = std::size_t{tree.parent.size()};
+  EliminationTree subtree(dim_subtree);
+  std::transform(tree.parent.cend() - static_cast<std::ptrdiff_t>(dim_subtree),
+                 tree.parent.cend(), subtree.parent.begin(),
+                 [&](const std::size_t node) {
                    return node == tree.no_parent ? subtree.no_parent
                                                  : node - (dim - dim_subtree);
                  });
   return subtree;
 }
 
-template <std::size_t dim>
-constexpr void clearSubtreeBack(EliminationTree<dim>& tree,
+constexpr void clearSubtreeBack(EliminationTree& tree,
                                 const std::size_t dim_subtree) {
-  std::fill(tree.parent.end() - dim_subtree, tree.parent.end(), tree.no_parent);
+  std::fill(tree.parent.end() - static_cast<std::ptrdiff_t>(dim_subtree),
+            tree.parent.end(), tree.no_parent);
 }
 
-template <std::size_t dim, std::size_t dim_subtree>
-constexpr void setSubtreeFront(EliminationTree<dim>& tree,
-                               const EliminationTree<dim_subtree>& subtree) {
-  static_assert(dim_subtree <= dim);
+constexpr void setSubtreeFront(EliminationTree& tree,
+                               const EliminationTree& subtree) {
+  pre(subtree.parent.size() <= tree.parent.size());
   std::ranges::copy(subtree.parent, tree.parent.begin());
 }
 

--- a/ctldl/symbolic/filled_in_sparsity.hpp
+++ b/ctldl/symbolic/filled_in_sparsity.hpp
@@ -15,9 +15,9 @@ template <auto sparsity,
 constexpr auto getFilledInSparsity() {
   static_assert(isSquare(sparsity));
   constexpr auto dim = std::size_t{sparsity.numRows()};
-  return makeSparsity<dim, dim>(
-      getEntriesWithFill<SparsityCSR(
-          getSparsityLowerTriangle<sparsity>(permutation))>());
+  return makeSparsityStatic<dim, dim>(
+      getEntriesWithFill<SparsityStaticCSR(
+          getSparsityStaticLowerTriangle<sparsity>(permutation))>());
 }
 
 }  // namespace ctldl

--- a/ctldl/symbolic/filled_in_sparsity_blocked.test.cpp
+++ b/ctldl/symbolic/filled_in_sparsity_blocked.test.cpp
@@ -12,7 +12,7 @@ namespace ctldl {
 namespace {
 
 BOOST_AUTO_TEST_CASE(FilledInSparsityBlockedEmptyTest) {
-  constexpr auto empty = makeEmptySparsity<1, 1>();
+  constexpr auto empty = makeEmptySparsityStatic<1, 1>();
   constexpr auto filled = getFilledInSparsityBlocked<empty, empty, empty>();
   CTLDL_TEST_SPARSITY_EQUAL(filled.block11, empty);
   CTLDL_TEST_SPARSITY_EQUAL(filled.block21, empty);
@@ -20,16 +20,16 @@ BOOST_AUTO_TEST_CASE(FilledInSparsityBlockedEmptyTest) {
 }
 
 BOOST_AUTO_TEST_CASE(FilledInSparsityBlockedNos2Test) {
-  constexpr auto sparsity11 = makeEmptySparsity<3, 3>();
+  constexpr auto sparsity11 = makeEmptySparsityStatic<3, 3>();
   constexpr auto sparsity21 =
-      makeSparsity<3, 3>({{0, 0}, {1, 1}, {1, 2}, {2, 1}, {2, 2}});
+      makeSparsityStatic<3, 3>({{0, 0}, {1, 1}, {1, 2}, {2, 1}, {2, 2}});
   constexpr auto sparsity22 = sparsity11;
 
   constexpr auto filled =
       getFilledInSparsityBlocked<sparsity11, sparsity21, sparsity22>();
 
-  constexpr auto expected = LowerTriangleBlocked{sparsity11, sparsity21,
-                                                 makeSparsity<3, 3>({{2, 1}})};
+  constexpr auto expected = LowerTriangleBlocked{
+      sparsity11, sparsity21, makeSparsityStatic<3, 3>({{2, 1}})};
   CTLDL_TEST_SPARSITY_EQUAL(filled.block11, expected.block11);
   CTLDL_TEST_SPARSITY_EQUAL(filled.block21, expected.block21);
   CTLDL_TEST_SPARSITY_EQUAL(filled.block22, expected.block22);

--- a/ctldl/symbolic/filled_in_sparsity_repeating.hpp
+++ b/ctldl/symbolic/filled_in_sparsity_repeating.hpp
@@ -17,8 +17,8 @@ constexpr auto getFilledInSparsityRepeating() {
   constexpr auto dim = std::size_t{sparsity_in_A.numRows()};
 
   const auto sparsity_filled = getFilledInSparsityRepeatingArrowhead<
-      sparsity_in_A, sparsity_in_B, makeEmptySparsity<0, dim>(), permutation,
-      PermutationStatic<0>{}>();
+      sparsity_in_A, sparsity_in_B, makeEmptySparsityStatic<0, dim>(),
+      permutation, PermutationStatic<0>{}>();
   return RepeatingBlockTridiagonal{sparsity_filled.diag,
                                    sparsity_filled.subdiag};
 };

--- a/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.hpp
+++ b/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.hpp
@@ -9,25 +9,25 @@
 #include <ctldl/sparsity/sparsity_permuted.hpp>
 #include <ctldl/symbolic/foreach_nonzero_with_fill_repeating_arrowhead.hpp>
 #include <ctldl/symbolic/repeating_block_tridiagonal_arrowhead.hpp>
+#include <ctldl/utility/contracts.hpp>
 
 #include <array>
 #include <cstddef>
 
 namespace ctldl {
 
-template <class SparsityDiag, class SparsitySubdiag, class SparsityOuter>
 constexpr auto getNumNonZerosWithFillRepeatingArrowhead(
-    const SparsityDiag& sparsity_A, const SparsitySubdiag& sparsity_B,
-    const SparsityOuter& sparsity_C) {
-  static_assert(isSquare<SparsityDiag>());
-  static_assert(isSquare<SparsitySubdiag>());
-  static_assert(SparsityDiag::numRows() == SparsitySubdiag::numRows());
-  constexpr auto dim = std::size_t{SparsityDiag::numRows()};
-  static_assert(SparsityOuter::numCols() == SparsityDiag::numCols());
-
+    const SparsityViewCSR sparsity_A, const SparsityViewCSR sparsity_B,
+    const SparsityViewCSR sparsity_C) {
+  pre(isSquare(sparsity_A));
+  pre(isSquare(sparsity_B));
+  pre(sparsity_A.numRows() == sparsity_B.numRows());
+  const auto dim = std::size_t{sparsity_A.numRows()};
+  pre(sparsity_C.numCols() == sparsity_A.numCols());
   RepeatingBlockTridiagonalArrowhead nnz{std::size_t{0}, std::size_t{0},
                                          std::size_t{0}};
-  const auto count_nonzero = [&](const std::size_t i, const std::size_t j) {
+  const auto count_nonzero = [dim, &nnz](const std::size_t i,
+                                         const std::size_t j) {
     if (i >= 2 * dim) {
       nnz.outer += 1;
     } else {
@@ -43,32 +43,15 @@ constexpr auto getNumNonZerosWithFillRepeatingArrowhead(
   return nnz;
 }
 
-template <auto sparsity_in_A, auto sparsity_in_B, auto sparsity_in_C,
-          auto permutation, auto permutation_C>
-constexpr auto getFilledInSparsityRepeatingArrowhead() {
-  static_assert(isSquare(sparsity_in_A));
-  static_assert(isSquare(sparsity_in_B));
-  static_assert(sparsity_in_B.numRows() == sparsity_in_A.numRows());
-  static_assert(sparsity_in_C.numCols() == sparsity_in_A.numCols());
-  constexpr auto dim = std::size_t{sparsity_in_A.numRows()};
-  constexpr auto dim_outer = std::size_t{sparsity_in_C.numRows()};
+struct EntryAdderRepeatingBlockTridiagonalArrowhead {
+  std::size_t dim;
+  RepeatingBlockTridiagonalArrowhead<std::span<Entry>, std::span<Entry>,
+                                     std::span<Entry>>
+      entries;
+  RepeatingBlockTridiagonalArrowhead<std::size_t, std::size_t, std::size_t>&
+      entry_index;
 
-  constexpr auto sparsity_A =
-      SparsityCSR(getSparsityLowerTriangle<sparsity_in_A>(permutation));
-  constexpr auto sparsity_B =
-      SparsityCSR(getSparsityPermuted(sparsity_in_B, permutation, permutation));
-  constexpr auto sparsity_C = SparsityCSR(
-      getSparsityPermuted(sparsity_in_C, permutation_C, permutation));
-
-  constexpr auto nnz = getNumNonZerosWithFillRepeatingArrowhead(
-      sparsity_A, sparsity_B, sparsity_C);
-
-  RepeatingBlockTridiagonalArrowhead entries{std::array<Entry, nnz.diag>{},
-                                             std::array<Entry, nnz.subdiag>{},
-                                             std::array<Entry, nnz.outer>{}};
-  RepeatingBlockTridiagonalArrowhead entry_index{std::size_t{0}, std::size_t{0},
-                                                 std::size_t{0}};
-  const auto add_nonzero = [&](const std::size_t i, const std::size_t j) {
+  constexpr void operator()(const std::size_t i, const std::size_t j) const {
     if (i >= 2 * dim) {
       entries.outer[entry_index.outer] = Entry{i - 2 * dim, j % dim};
       entry_index.outer += 1;
@@ -81,7 +64,40 @@ constexpr auto getFilledInSparsityRepeatingArrowhead() {
         entry_index.subdiag += 1;
       }
     }
-  };
+  }
+};
+
+template <auto sparsity_in_A, auto sparsity_in_B, auto sparsity_in_C,
+          auto permutation, auto permutation_C>
+constexpr auto getFilledInSparsityRepeatingArrowhead() {
+  static_assert(isSquare(sparsity_in_A));
+  static_assert(isSquare(sparsity_in_B));
+  static_assert(sparsity_in_B.numRows() == sparsity_in_A.numRows());
+  static_assert(sparsity_in_C.numCols() == sparsity_in_A.numCols());
+  constexpr auto dim = std::size_t{sparsity_in_A.numRows()};
+  constexpr auto dim_outer = std::size_t{sparsity_in_C.numRows()};
+
+  constexpr auto sparsity_A = SparsityStaticCSR(
+      getSparsityStaticLowerTriangle<sparsity_in_A>(permutation));
+  constexpr auto sparsity_B = SparsityStaticCSR(
+      getSparsityStaticPermuted(sparsity_in_B, permutation, permutation));
+  constexpr auto sparsity_C = SparsityStaticCSR(
+      getSparsityStaticPermuted(sparsity_in_C, permutation_C, permutation));
+
+  constexpr auto nnz = getNumNonZerosWithFillRepeatingArrowhead(
+      sparsity_A, sparsity_B, sparsity_C);
+
+  RepeatingBlockTridiagonalArrowhead entries{
+      std::array<Entry, nnz.diag>{}, std::array<Entry, nnz.subdiag>{},
+      std::array<Entry, nnz.outer>{}};
+  RepeatingBlockTridiagonalArrowhead entry_index{std::size_t{0}, std::size_t{0},
+                                                 std::size_t{0}};
+  const EntryAdderRepeatingBlockTridiagonalArrowhead add_nonzero{
+      dim,
+      RepeatingBlockTridiagonalArrowhead{std::span<Entry>{entries.diag},
+                                         std::span<Entry>{entries.subdiag},
+                                         std::span<Entry>{entries.outer}},
+      entry_index};
   foreachNonZeroWithFillRepeatingArrowhead(sparsity_A, sparsity_B, sparsity_C,
                                            add_nonzero);
 
@@ -91,9 +107,9 @@ constexpr auto getFilledInSparsityRepeatingArrowhead() {
   sortEntriesRowMajorSorted(entries.outer);
 
   return RepeatingBlockTridiagonalArrowhead{
-      makeSparsity<dim, dim>(entries.diag),
-      makeSparsity<dim, dim>(entries.subdiag),
-      makeSparsity<dim_outer, dim>(entries.outer)};
+      makeSparsityStatic<dim, dim>(entries.diag),
+      makeSparsityStatic<dim, dim>(entries.subdiag),
+      makeSparsityStatic<dim_outer, dim>(entries.outer)};
 };
 
 }  // namespace ctldl

--- a/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.test.cpp
+++ b/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.test.cpp
@@ -12,7 +12,7 @@ namespace ctldl {
 namespace {
 
 BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadEmptyTest) {
-  constexpr auto empty = makeEmptySparsity<1, 1>();
+  constexpr auto empty = makeEmptySparsityStatic<1, 1>();
   constexpr PermutationStatic<1> permutation{};
   constexpr auto filled =
       getFilledInSparsityRepeatingArrowhead<empty, empty, empty, permutation,
@@ -21,37 +21,40 @@ BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadEmptyTest) {
 }
 
 BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadFromDiagonalTest) {
-  constexpr auto sparsity_A = makeSparsity<3, 3>({{1, 0}, {2, 1}});
-  constexpr auto sparsity_B = makeEmptySparsity<3, 3>();
-  constexpr auto sparsity_C = makeSparsity<1, 3>({{0, 0}});
+  constexpr auto sparsity_A = makeSparsityStatic<3, 3>({{1, 0}, {2, 1}});
+  constexpr auto sparsity_B = makeEmptySparsityStatic<3, 3>();
+  constexpr auto sparsity_C = makeSparsityStatic<1, 3>({{0, 0}});
   constexpr PermutationStatic<3> permutation{};
   constexpr PermutationStatic<1> permutation_outer{};
   constexpr auto filled =
       getFilledInSparsityRepeatingArrowhead<sparsity_A, sparsity_B, sparsity_C,
                                             permutation, permutation_outer>();
 
-  constexpr auto filled_correct = makeSparsity<1, 3>({{0, 0}, {0, 1}, {0, 2}});
+  constexpr auto filled_correct =
+      makeSparsityStatic<1, 3>({{0, 0}, {0, 1}, {0, 2}});
   CTLDL_TEST_SPARSITY_EQUAL(filled.outer, filled_correct);
 }
 
 BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadFromBothTest) {
-  constexpr auto sparsity_A = makeSparsity<3, 3>({{2, 1}});
-  constexpr auto sparsity_B = makeSparsity<3, 3>({{1, 0}});
-  constexpr auto sparsity_C = makeSparsity<1, 3>({{0, 0}});
+  constexpr auto sparsity_A = makeSparsityStatic<3, 3>({{2, 1}});
+  constexpr auto sparsity_B = makeSparsityStatic<3, 3>({{1, 0}});
+  constexpr auto sparsity_C = makeSparsityStatic<1, 3>({{0, 0}});
   constexpr PermutationStatic<3> permutation{};
   constexpr PermutationStatic<1> permutation_outer{};
   constexpr auto filled =
       getFilledInSparsityRepeatingArrowhead<sparsity_A, sparsity_B, sparsity_C,
                                             permutation, permutation_outer>();
 
-  constexpr auto filled_correct = makeSparsity<1, 3>({{0, 0}, {0, 1}, {0, 2}});
+  constexpr auto filled_correct =
+      makeSparsityStatic<1, 3>({{0, 0}, {0, 1}, {0, 2}});
   CTLDL_TEST_SPARSITY_EQUAL(filled.outer, filled_correct);
 }
 
 BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadBackwardsTest) {
-  constexpr auto sparsity_A = makeEmptySparsity<4, 4>();
-  constexpr auto sparsity_B = makeSparsity<4, 4>({{0, 1}, {1, 2}, {2, 3}});
-  constexpr auto sparsity_C = makeSparsity<1, 4>({{0, 3}});
+  constexpr auto sparsity_A = makeEmptySparsityStatic<4, 4>();
+  constexpr auto sparsity_B =
+      makeSparsityStatic<4, 4>({{0, 1}, {1, 2}, {2, 3}});
+  constexpr auto sparsity_C = makeSparsityStatic<1, 4>({{0, 3}});
   constexpr PermutationStatic<4> permutation{};
   constexpr PermutationStatic<1> permutation_outer{};
   constexpr auto filled =
@@ -59,7 +62,7 @@ BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadBackwardsTest) {
                                             permutation, permutation_outer>();
 
   constexpr auto filled_correct =
-      makeSparsity<1, 4>({{0, 0}, {0, 1}, {0, 2}, {0, 3}});
+      makeSparsityStatic<1, 4>({{0, 0}, {0, 1}, {0, 2}, {0, 3}});
   CTLDL_TEST_SPARSITY_EQUAL(filled.outer, filled_correct);
 }
 

--- a/ctldl/symbolic/foreach_ancestor_in_subtree.hpp
+++ b/ctldl/symbolic/foreach_ancestor_in_subtree.hpp
@@ -1,18 +1,19 @@
 #pragma once
 
+#include <ctldl/sparsity/sparsity_csr.hpp>
 #include <ctldl/symbolic/elimination_tree.hpp>
 
 #include <array>
 #include <cstddef>
+#include <span>
 
 
 namespace ctldl {
 
-template <class Sparsity, std::size_t dim, class GetParentFunction,
-          class BinaryFunction>
+template <class GetParentFunction, class BinaryFunction>
 constexpr void foreachAncestorInSubtreeImpl(
-    const Sparsity& sparsity, const GetParentFunction get_parent,
-    const std::size_t row_index, std::array<std::size_t, dim>& visitor,
+    const SparsityViewCSR sparsity, const GetParentFunction get_parent,
+    const std::size_t row_index, const std::span<std::size_t> visitor,
     BinaryFunction f, const std::size_t row_offset = 0,
     const std::size_t col_offset = 0) {
   const auto i = row_index + row_offset;
@@ -26,11 +27,11 @@ constexpr void foreachAncestorInSubtreeImpl(
   }
 }
 
-template <class Sparsity, std::size_t dim, class BinaryFunction>
-constexpr void foreachAncestorInSubtree(const Sparsity& sparsity,
-                                        const EliminationTree<dim>& tree,
+template <class BinaryFunction>
+constexpr void foreachAncestorInSubtree(const SparsityViewCSR sparsity,
+                                        const EliminationTree& tree,
                                         const std::size_t row_index,
-                                        std::array<std::size_t, dim>& visitor,
+                                        const std::span<std::size_t> visitor,
                                         BinaryFunction f,
                                         const std::size_t row_offset = 0,
                                         const std::size_t col_offset = 0) {

--- a/ctldl/symbolic/foreach_nonzero_with_fill.hpp
+++ b/ctldl/symbolic/foreach_nonzero_with_fill.hpp
@@ -1,23 +1,25 @@
 #pragma once
 
 #include <ctldl/sparsity/is_square.hpp>
+#include <ctldl/sparsity/sparsity_csr.hpp>
 #include <ctldl/symbolic/compute_elimination_tree.hpp>
 #include <ctldl/symbolic/foreach_ancestor_in_subtree.hpp>
+#include <ctldl/utility/contracts.hpp>
 
-#include <array>
 #include <cstddef>
 #include <numeric>
+#include <vector>
 
 namespace ctldl {
 
-template <class Sparsity, class UnaryFunction>
-constexpr void foreachNonZeroWithFill(const Sparsity& sparsity,
+template <class UnaryFunction>
+constexpr void foreachNonZeroWithFill(const SparsityViewCSR sparsity,
                                       UnaryFunction f) {
-  static_assert(isSquare<Sparsity>());
-  constexpr auto dim = Sparsity::numRows();
+  pre(isSquare(sparsity));
+  const auto dim = sparsity.numRows();
 
   const auto tree = computeEliminationTree(sparsity);
-  std::array<std::size_t, dim> visitor;
+  std::vector<std::size_t> visitor(dim);
   std::iota(visitor.begin(), visitor.end(), 0);
   for (std::size_t i = 0; i < dim; ++i) {
     foreachAncestorInSubtree(sparsity, tree, i, visitor, f);

--- a/ctldl/symbolic/get_entries_with_fill.hpp
+++ b/ctldl/symbolic/get_entries_with_fill.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ctldl/sparsity/entry.hpp>
+#include <ctldl/sparsity/sparsity_csr.hpp>
 #include <ctldl/sparsity/sort_entries_row_major_sorted.hpp>
 #include <ctldl/symbolic/foreach_nonzero_with_fill.hpp>
 #include <ctldl/utility/fix_init_if_zero_length_array.hpp>
@@ -10,8 +11,7 @@
 
 namespace ctldl {
 
-template <class Sparsity>
-constexpr auto getNumNonZerosWithFill(const Sparsity& sparsity) {
+constexpr auto getNumNonZerosWithFill(const SparsityViewCSR sparsity) {
   std::size_t nnz = 0;
   const auto count_nonzero = [&nnz](const std::size_t /*i*/,
                                     const std::size_t /*j*/) { nnz += 1; };

--- a/ctldl/symbolic/is_chordal_blocked.hpp
+++ b/ctldl/symbolic/is_chordal_blocked.hpp
@@ -4,6 +4,7 @@
 #include <ctldl/sparsity/is_sparsity_equal.hpp>
 #include <ctldl/sparsity/is_square.hpp>
 #include <ctldl/symbolic/filled_in_sparsity_blocked.hpp>
+#include <ctldl/utility/contracts.hpp>
 
 namespace ctldl {
 
@@ -11,8 +12,8 @@ template <class Sparsity11, class Sparsity21, class Sparsity22>
 constexpr bool isChordalBlocked(const Sparsity11& sparsity11,
                                 const Sparsity21& sparsity21,
                                 const Sparsity22& sparsity22) {
-  static_assert(isSquare<Sparsity11>());
-  static_assert(isSquare<Sparsity22>());
+  pre(isSquare(sparsity11));
+  pre(isSquare(sparsity22));
   static_assert(Sparsity21::numCols() == Sparsity11::numCols());
   static_assert(Sparsity22::numRows() == Sparsity21::numRows());
   if (!isLowerTriangle(sparsity11) || !isLowerTriangle(sparsity22)) {

--- a/ctldl/utility/contracts.hpp
+++ b/ctldl/utility/contracts.hpp
@@ -8,23 +8,23 @@ void contractHandlePreconditionViolation(std::source_location source_location);
 void contractHandlePostconditionViolation(std::source_location source_location);
 void contractHandleAssertionViolation(std::source_location source_location);
 
-inline void pre(bool condition, const std::source_location source_location =
-                                    std::source_location{}) {
+constexpr void pre(bool condition, const std::source_location source_location =
+                                       std::source_location{}) {
   if (condition) {
     return;
   }
   contractHandlePreconditionViolation(source_location);
 }
 
-inline void post(bool condition, const std::source_location source_location =
-                                     std::source_location{}) {
+constexpr void post(bool condition, const std::source_location source_location =
+                                        std::source_location{}) {
   if (condition) {
     return;
   }
   contractHandlePostconditionViolation(source_location);
 }
 
-inline void contract_assert(
+constexpr void contract_assert(
     bool condition,
     const std::source_location source_location = std::source_location{}) {
   if (condition) {

--- a/examples/repeating/example_nos4.cpp
+++ b/examples/repeating/example_nos4.cpp
@@ -15,7 +15,7 @@ constexpr int dim = 10;
 
 class MatrixA {
  public:
-  static constexpr auto sparsity = ctldl::makeSparsity<dim, dim>({
+  static constexpr auto sparsity = ctldl::makeSparsityStatic<dim, dim>({
       {0, 0},
       {1, 0}, {1, 1},
       {2, 0}, {2, 2},
@@ -64,7 +64,7 @@ class MatrixA {
 };
 
 struct MatrixB {
-  static constexpr auto sparsity = ctldl::makeSparsity<dim, dim>({
+  static constexpr auto sparsity = ctldl::makeSparsityStatic<dim, dim>({
       {1, 1},
       {2, 0}, {2, 1}, {2, 4}, {2, 5},
       {3, 0}, {3, 1}, {3, 3}, {3, 4}, {3, 5},

--- a/examples/repeating/example_tridiagonal.cpp
+++ b/examples/repeating/example_tridiagonal.cpp
@@ -46,7 +46,7 @@ struct MatrixA {
 
 struct MatrixB {
   static constexpr auto sparsity =
-      ctldl::makeSparsity<dim, dim>({ctldl::Entry{0, dim - 1}});
+      ctldl::makeSparsityStatic<dim, dim>({ctldl::Entry{0, dim - 1}});
 
   constexpr double valueAt(const std::size_t /*i*/) const { return -1.0; }
 };

--- a/examples/repeating/mtx_includes/suitesparse/Bai/mhdb416/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/suitesparse/Bai/mhdb416/ctldl_repeating_mtx_include.hpp
@@ -11,20 +11,20 @@
 #include <cstddef>
 
 constexpr auto getRepeatingMtxSparsityStart() {
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr auto next = ctldl::makeEmptySparsity<16, 0>();
-  constexpr auto outer = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
+  constexpr auto next = ctldl::makeEmptySparsityStatic<16, 0>();
+  constexpr auto outer = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeStart{diag, next, outer, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityTridiag() {
-  constexpr auto diag = ctldl::makeSparsity<16, 16>(
+  constexpr auto diag = ctldl::makeSparsityStatic<16, 16>(
       {{0, 0},   {1, 0},   {1, 1},   {2, 2},   {3, 2},   {3, 3},   {4, 4},
        {5, 4},   {5, 5},   {6, 4},   {6, 5},   {6, 6},   {7, 4},   {7, 5},
        {7, 6},   {7, 7},   {8, 8},   {9, 8},   {9, 9},   {10, 10}, {11, 10},
        {11, 11}, {12, 12}, {13, 12}, {13, 13}, {14, 14}, {15, 14}, {15, 15}});
-  constexpr auto subdiag = ctldl::makeSparsity<16, 16>(
+  constexpr auto subdiag = ctldl::makeSparsityStatic<16, 16>(
       {{0, 1},   {1, 1},   {2, 2},   {3, 2},   {2, 3},   {3, 3},   {4, 5},
        {5, 5},   {6, 5},   {7, 5},   {4, 7},   {5, 7},   {6, 7},   {7, 7},
        {8, 9},   {9, 9},   {10, 11}, {11, 11}, {12, 12}, {13, 12}, {12, 13},
@@ -35,16 +35,16 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
 }
 
 constexpr auto getRepeatingMtxSparsityLink() {
-  constexpr auto prev = ctldl::makeEmptySparsity<0, 16>();
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr auto next = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto prev = ctldl::makeEmptySparsityStatic<0, 16>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
+  constexpr auto next = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeLink{prev, diag, next, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityOuter() {
-  constexpr auto subdiag = ctldl::makeEmptySparsity<0, 16>();
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto subdiag = ctldl::makeEmptySparsityStatic<0, 16>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeOuter{subdiag, diag, permutation};
 }

--- a/examples/repeating/mtx_includes/suitesparse/HB/nos2/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/suitesparse/HB/nos2/ctldl_repeating_mtx_include.hpp
@@ -11,32 +11,33 @@
 #include <cstddef>
 
 constexpr auto getRepeatingMtxSparsityStart() {
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr auto next = ctldl::makeEmptySparsity<3, 0>();
-  constexpr auto outer = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
+  constexpr auto next = ctldl::makeEmptySparsityStatic<3, 0>();
+  constexpr auto outer = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeStart{diag, next, outer, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityTridiag() {
-  constexpr auto diag = ctldl::makeSparsity<3, 3>({{0, 0}, {1, 1}, {2, 2}});
+  constexpr auto diag =
+      ctldl::makeSparsityStatic<3, 3>({{0, 0}, {1, 1}, {2, 2}});
   constexpr auto subdiag =
-      ctldl::makeSparsity<3, 3>({{0, 0}, {1, 1}, {2, 1}, {1, 2}, {2, 2}});
+      ctldl::makeSparsityStatic<3, 3>({{0, 0}, {1, 1}, {2, 1}, {1, 2}, {2, 2}});
   constexpr auto permutation = ctldl::PermutationStatic<3>{{0, 1, 2}};
   return ctldl::SparsityToFactorizeTridiagonal{diag, subdiag, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityLink() {
-  constexpr auto prev = ctldl::makeEmptySparsity<0, 3>();
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr auto next = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto prev = ctldl::makeEmptySparsityStatic<0, 3>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
+  constexpr auto next = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeLink{prev, diag, next, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityOuter() {
-  constexpr auto subdiag = ctldl::makeEmptySparsity<0, 3>();
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto subdiag = ctldl::makeEmptySparsityStatic<0, 3>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeOuter{subdiag, diag, permutation};
 }

--- a/examples/repeating/mtx_includes/suitesparse/HB/nos4/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/suitesparse/HB/nos4/ctldl_repeating_mtx_include.hpp
@@ -11,15 +11,15 @@
 #include <cstddef>
 
 constexpr auto getRepeatingMtxSparsityStart() {
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr auto next = ctldl::makeEmptySparsity<10, 0>();
-  constexpr auto outer = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
+  constexpr auto next = ctldl::makeEmptySparsityStatic<10, 0>();
+  constexpr auto outer = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeStart{diag, next, outer, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityTridiag() {
-  constexpr auto diag = ctldl::makeSparsity<10, 10>({
+  constexpr auto diag = ctldl::makeSparsityStatic<10, 10>({
     {0,0},
     {1,0},
     {2,0},
@@ -37,7 +37,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
     {9,8},
     {9,9},
   });
-  constexpr auto subdiag = ctldl::makeSparsity<10, 10>({
+  constexpr auto subdiag = ctldl::makeSparsityStatic<10, 10>({
     {2,0},
     {3,0},
     {1,1},
@@ -66,16 +66,16 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
 }
 
 constexpr auto getRepeatingMtxSparsityLink() {
-  constexpr auto prev = ctldl::makeEmptySparsity<0, 10>();
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr auto next = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto prev = ctldl::makeEmptySparsityStatic<0, 10>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
+  constexpr auto next = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeLink{prev, diag, next, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityOuter() {
-  constexpr auto subdiag = ctldl::makeEmptySparsity<0, 10>();
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto subdiag = ctldl::makeEmptySparsityStatic<0, 10>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeOuter{subdiag, diag, permutation};
 }

--- a/examples/repeating/mtx_includes/transworhp/laufkatze/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/transworhp/laufkatze/ctldl_repeating_mtx_include.hpp
@@ -11,7 +11,7 @@
 #include <cstddef>
 
 constexpr auto getRepeatingMtxSparsityStart() {
-  constexpr auto diag = ctldl::makeSparsity<11, 11>({
+  constexpr auto diag = ctldl::makeSparsityStatic<11, 11>({
     {0,0},
     {1,1},
     {2,2},
@@ -26,7 +26,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
     {9,9},
     {10,10},
   });
-  constexpr auto next = ctldl::makeSparsity<20, 11>({
+  constexpr auto next = ctldl::makeSparsityStatic<20, 11>({
     {0,0},
     {0,1},
     {1,1},
@@ -48,7 +48,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
     {7,10},
     {8,10},
   });
-  constexpr auto outer = ctldl::makeSparsity<1, 11>({
+  constexpr auto outer = ctldl::makeSparsityStatic<1, 11>({
     {0,1},
     {0,2},
     {0,3},
@@ -75,7 +75,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
 }
 
 constexpr auto getRepeatingMtxSparsityTridiag() {
-  constexpr auto diag = ctldl::makeSparsity<20, 20>({
+  constexpr auto diag = ctldl::makeSparsityStatic<20, 20>({
     {9,0},
     {10,0},
     {10,1},
@@ -113,7 +113,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
     {18,18},
     {19,19},
   });
-  constexpr auto subdiag = ctldl::makeSparsity<20, 20>({
+  constexpr auto subdiag = ctldl::makeSparsityStatic<20, 20>({
     {0,9},
     {0,10},
     {1,10},
@@ -163,15 +163,15 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
 }
 
 constexpr auto getRepeatingMtxSparsityLink() {
-  constexpr auto prev = ctldl::makeEmptySparsity<0, 20>();
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr auto next = ctldl::makeEmptySparsity<1, 0>();
+  constexpr auto prev = ctldl::makeEmptySparsityStatic<0, 20>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
+  constexpr auto next = ctldl::makeEmptySparsityStatic<1, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeLink{prev, diag, next, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityOuter() {
-  constexpr auto subdiag = ctldl::makeSparsity<1, 20>({
+  constexpr auto subdiag = ctldl::makeSparsityStatic<1, 20>({
     {0,0},
     {0,1},
     {0,2},
@@ -191,7 +191,7 @@ constexpr auto getRepeatingMtxSparsityOuter() {
     {0,18},
     {0,19},
   });
-  constexpr auto diag = ctldl::makeSparsity<1, 1>({
+  constexpr auto diag = ctldl::makeSparsityStatic<1, 1>({
     {0,0},
   });
   constexpr auto permutation = ctldl::PermutationStatic<1>{{

--- a/examples/repeating/mtx_includes/transworhp/opal/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/transworhp/opal/ctldl_repeating_mtx_include.hpp
@@ -11,15 +11,15 @@
 #include <cstddef>
 
 constexpr auto getRepeatingMtxSparsityStart() {
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr auto next = ctldl::makeEmptySparsity<22, 0>();
-  constexpr auto outer = ctldl::makeEmptySparsity<2, 0>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
+  constexpr auto next = ctldl::makeEmptySparsityStatic<22, 0>();
+  constexpr auto outer = ctldl::makeEmptySparsityStatic<2, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeStart{diag, next, outer, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityTridiag() {
-  constexpr auto diag = ctldl::makeSparsity<22, 22>({
+  constexpr auto diag = ctldl::makeSparsityStatic<22, 22>({
     {0,0},
     {1,0},
     {3,0},
@@ -87,7 +87,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
     {12,12},
     {13,13},
   });
-  constexpr auto subdiag = ctldl::makeSparsity<22, 22>({
+  constexpr auto subdiag = ctldl::makeSparsityStatic<22, 22>({
     {0,14},
     {2,14},
     {3,14},
@@ -136,7 +136,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
 }
 
 constexpr auto getRepeatingMtxSparsityLink() {
-  constexpr auto prev = ctldl::makeSparsity<14, 22>({
+  constexpr auto prev = ctldl::makeSparsityStatic<14, 22>({
     {0,14},
     {2,14},
     {3,14},
@@ -157,7 +157,7 @@ constexpr auto getRepeatingMtxSparsityLink() {
     {4,21},
     {7,21},
   });
-  constexpr auto diag = ctldl::makeSparsity<14, 14>({
+  constexpr auto diag = ctldl::makeSparsityStatic<14, 14>({
     {0,0},
     {10,0},
     {11,0},
@@ -189,7 +189,7 @@ constexpr auto getRepeatingMtxSparsityLink() {
     {12,12},
     {13,13},
   });
-  constexpr auto next = ctldl::makeSparsity<2, 14>({
+  constexpr auto next = ctldl::makeSparsityStatic<2, 14>({
     {0,2},
     {0,3},
     {0,4},
@@ -219,7 +219,7 @@ constexpr auto getRepeatingMtxSparsityLink() {
 }
 
 constexpr auto getRepeatingMtxSparsityOuter() {
-  constexpr auto subdiag = ctldl::makeSparsity<2, 22>({
+  constexpr auto subdiag = ctldl::makeSparsityStatic<2, 22>({
     {0,0},
     {0,1},
     {0,2},
@@ -248,7 +248,7 @@ constexpr auto getRepeatingMtxSparsityOuter() {
     {0,21},
     {1,21},
   });
-  constexpr auto diag = ctldl::makeSparsity<2, 2>({
+  constexpr auto diag = ctldl::makeSparsityStatic<2, 2>({
     {0,0},
     {1,1},
   });

--- a/examples/repeating/mtx_includes/transworhp/spline/ctldl_repeating_mtx_include.hpp
+++ b/examples/repeating/mtx_includes/transworhp/spline/ctldl_repeating_mtx_include.hpp
@@ -11,13 +11,13 @@
 #include <cstddef>
 
 constexpr auto getRepeatingMtxSparsityStart() {
-  constexpr auto diag = ctldl::makeSparsity<4, 4>({
+  constexpr auto diag = ctldl::makeSparsityStatic<4, 4>({
     {0,0},
     {1,1},
     {2,2},
     {3,3},
   });
-  constexpr auto next = ctldl::makeSparsity<7, 4>({
+  constexpr auto next = ctldl::makeSparsityStatic<7, 4>({
     {0,0},
     {0,1},
     {1,1},
@@ -25,7 +25,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
     {1,3},
     {2,3},
   });
-  constexpr auto outer = ctldl::makeEmptySparsity<0, 4>();
+  constexpr auto outer = ctldl::makeEmptySparsityStatic<0, 4>();
   constexpr auto permutation = ctldl::PermutationStatic<4>{{
     0,
     1,
@@ -36,7 +36,7 @@ constexpr auto getRepeatingMtxSparsityStart() {
 }
 
 constexpr auto getRepeatingMtxSparsityTridiag() {
-  constexpr auto diag = ctldl::makeSparsity<7, 7>({
+  constexpr auto diag = ctldl::makeSparsityStatic<7, 7>({
     {0,0},
     {3,0},
     {4,0},
@@ -51,7 +51,7 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
     {5,5},
     {6,6},
   });
-  constexpr auto subdiag = ctldl::makeSparsity<7, 7>({
+  constexpr auto subdiag = ctldl::makeSparsityStatic<7, 7>({
     {0,3},
     {0,4},
     {1,4},
@@ -72,16 +72,16 @@ constexpr auto getRepeatingMtxSparsityTridiag() {
 }
 
 constexpr auto getRepeatingMtxSparsityLink() {
-  constexpr auto prev = ctldl::makeEmptySparsity<0, 7>();
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
-  constexpr auto next = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto prev = ctldl::makeEmptySparsityStatic<0, 7>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
+  constexpr auto next = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeLink{prev, diag, next, permutation};
 }
 
 constexpr auto getRepeatingMtxSparsityOuter() {
-  constexpr auto subdiag = ctldl::makeEmptySparsity<0, 7>();
-  constexpr auto diag = ctldl::makeEmptySparsity<0, 0>();
+  constexpr auto subdiag = ctldl::makeEmptySparsityStatic<0, 7>();
+  constexpr auto diag = ctldl::makeEmptySparsityStatic<0, 0>();
   constexpr ctldl::PermutationStatic<0> permutation{};
   return ctldl::SparsityToFactorizeOuter{subdiag, diag, permutation};
 }

--- a/examples/single/example_indef_single.cpp
+++ b/examples/single/example_indef_single.cpp
@@ -15,7 +15,7 @@ constexpr int dim = 2;
 constexpr ctldl::PermutationStatic<dim> permutation{{0, 1}};
 
 struct Matrix {
-  static constexpr auto sparsity = ctldl::makeSparsity<dim, dim>({{1, 0}});
+  static constexpr auto sparsity = ctldl::makeSparsityStatic<dim, dim>({{1, 0}});
 
   std::array<double, sparsity.nnz()> values;
   constexpr double valueAt(const std::size_t i) const {

--- a/examples/single/example_lfat5.cpp
+++ b/examples/single/example_lfat5.cpp
@@ -18,7 +18,7 @@ constexpr ctldl::PermutationStatic<dim> permutation{
     {13, 11, 12, 8, 7, 0, 4, 3, 9, 1, 5, 10, 2, 6}};
 
 struct Matrix {
-  static constexpr auto sparsity = ctldl::makeSparsity<dim, dim>(
+  static constexpr auto sparsity = ctldl::makeSparsityStatic<dim, dim>(
       {{0, 0},   {3, 0},   {4, 0},   {1, 1},   {5, 1},   {2, 2},
        {6, 2},   {3, 3},   {7, 3},   {8, 3},   {4, 4},   {7, 4},
        {8, 4},   {5, 5},   {9, 5},   {6, 6},   {10, 6},  {7, 7},

--- a/tests/multiply_factorize_solve_correct/repeating/test_functor.hpp
+++ b/tests/multiply_factorize_solve_correct/repeating/test_functor.hpp
@@ -7,6 +7,7 @@
 #include <ctldl/matrix/multiply_repeating_block_tridiagonal.hpp>
 #include <ctldl/permutation/permutation.hpp>
 #include <ctldl/sparsity/is_square.hpp>
+#include <ctldl/sparsity/sparsity.hpp>
 #include <ctldl/vector/block.hpp>
 #include <ctldl/vector/flatten.hpp>
 
@@ -27,8 +28,8 @@ struct TesterMultiplyFactorizeSolveCorrectRepeating {
   void operator()(const SolutionGenerator& solution_generator,
                   const std::size_t num_repetitions,
                   std::mt19937& value_generator) const {
-    constexpr auto& sparsity_A = TestMatrixA::Matrix::sparsity;
-    constexpr auto& sparsity_B = TestMatrixB::Matrix::sparsity;
+    constexpr SparsityStatic sparsity_A = TestMatrixA::Matrix::sparsity;
+    constexpr SparsityStatic sparsity_B = TestMatrixB::Matrix::sparsity;
 
     static_assert(isSquare(sparsity_A));
     static_assert(isSquare(sparsity_B));

--- a/tests/test_matrices/repeating/nos4.hpp
+++ b/tests/test_matrices/repeating/nos4.hpp
@@ -15,7 +15,7 @@ struct TestMatrixNos4A {
 
   class Matrix {
    public:
-    static constexpr auto sparsity = makeSparsity<block_dim, block_dim>({
+    static constexpr auto sparsity = makeSparsityStatic<block_dim, block_dim>({
         {0, 0},
         {1, 0}, {1, 1},
         {2, 0}, {2, 2},
@@ -81,7 +81,7 @@ template <class Value>
 struct TestMatrixNos4B {
   static constexpr int block_dim = 10;
   struct Matrix {
-    static constexpr auto sparsity = makeSparsity<block_dim, block_dim>({
+    static constexpr auto sparsity = makeSparsityStatic<block_dim, block_dim>({
         // empty row
         {1, 1},
         {2, 0}, {2, 1}, {2, 4}, {2, 5},

--- a/tests/test_matrices/repeating/tridiagonal.hpp
+++ b/tests/test_matrices/repeating/tridiagonal.hpp
@@ -60,7 +60,7 @@ template <int block_dim, class Value>
 struct TestMatrixSingleEntryTopRight {
   struct Matrix {
     static constexpr auto sparsity =
-        makeSparsity<block_dim, block_dim>({Entry{0, block_dim - 1}});
+        makeSparsityStatic<block_dim, block_dim>({Entry{0, block_dim - 1}});
 
     constexpr auto valueAt(const std::size_t /*i*/) const {
       return Value{-1.0};

--- a/tests/test_matrices/repeating/tridiagonal.hpp
+++ b/tests/test_matrices/repeating/tridiagonal.hpp
@@ -29,11 +29,11 @@ struct TestMatrixTridiagonal {
         std::array<Entry, std::size_t{nnz()}> ret;
         fixInitIfZeroLengthArray(ret);
         std::size_t entry_index = 0;
-        for (std::size_t i = 0; i < numRows(); ++i) {
+        for (std::size_t i = 0; i < std::size_t{numRows()}; ++i) {
           ret[entry_index] = {i, i, 2.0};
           entry_index += 1;
         }
-        for (std::size_t i = 1; i < numRows(); ++i) {
+        for (std::size_t i = 1; i < std::size_t{numRows()}; ++i) {
           ret[entry_index] = {i, i - 1, -1.0};
           entry_index += 1;
         }

--- a/tests/test_matrices/single/lfat5.hpp
+++ b/tests/test_matrices/single/lfat5.hpp
@@ -12,7 +12,7 @@ template <class Value>
 struct TestMatrixLFAT5 {
   static constexpr int dim = 14;
   struct Matrix {
-    static constexpr auto sparsity = makeSparsity<dim, dim>(
+    static constexpr auto sparsity = makeSparsityStatic<dim, dim>(
         {{0, 0},   {3, 0},   {4, 0},   {1, 1},   {5, 1},   {2, 2},
          {6, 2},   {3, 3},   {7, 3},   {8, 3},   {4, 4},   {7, 4},
          {8, 4},   {5, 5},   {9, 5},   {6, 6},   {10, 6},  {7, 7},

--- a/tests/test_matrices/single/random.hpp
+++ b/tests/test_matrices/single/random.hpp
@@ -17,7 +17,7 @@ struct TestMatrixRandom {
   }
 
   struct Matrix {
-    static constexpr auto sparsity = Sparsity(sparsity_in);
+    static constexpr auto sparsity = SparsityStatic(sparsity_in);
     std::array<Value, sparsity.nnz()> values;
     Value valueAt(const std::size_t entry_index) const {
       return values[entry_index];

--- a/tests/utility/random/procedural_test_matrix.hpp
+++ b/tests/utility/random/procedural_test_matrix.hpp
@@ -42,7 +42,7 @@ struct TestMatrixFromGenerator {
       BoolMatrixDistribution<num_rows, num_cols>{}, generator);
   static constexpr auto is_nonzero =
       applyRandomMatrixSparsityKind<kind>(is_nonzero_generated.result);
-  static constexpr auto sparsity = makeSparsity<num_rows, num_cols>(
+  static constexpr auto sparsity = makeSparsityStatic<num_rows, num_cols>(
       makeSparseEntriesFromBoolMatrix<is_nonzero>());
   using Base = TestMatrixRandom<sparsity, Value>;
 


### PR DESCRIPTION
Make a distinction between Sparsity with static size (needed to store them at compile-time), Sparsity with dynamic size and simple view. This allows removing some templating.