### PR TITLE
Clarify static sparsity construction

### DIFF
--- a/ctldl/sparsity/sparsity.hpp
+++ b/ctldl/sparsity/sparsity.hpp
@@ -3,6 +3,7 @@
 #include <ctldl/sparsity/entry.hpp>
 #include <ctldl/utility/contracts.hpp>
 #include <ctldl/utility/fix_init_if_zero_length_array.hpp>
+#include <ctldl/utility/static_sized_range.hpp>
 
 #include <algorithm>
 #include <array>
@@ -52,10 +53,10 @@ SparsityStatic(const SparsityIn& sparsity_in)
     -> SparsityStatic<std::tuple_size_v<decltype(SparsityIn::entries())>,
                       SparsityIn::numRows(), SparsityIn::numCols()>;
 
-template <std::size_t num_rows, std::size_t num_cols, class Entries>
+template <std::size_t num_rows, std::size_t num_cols,
+          static_sized_range Entries>
 constexpr auto makeSparsityStatic(const Entries& entries) {
-  using std::size;
-  constexpr auto nnz = std::size_t{size(Entries{})};
+  constexpr auto nnz = range_static_size_v<Entries>;
   return SparsityStatic<nnz, num_rows, num_cols>(entries);
 }
 

--- a/ctldl/sparsity/sparsity_csr.hpp
+++ b/ctldl/sparsity/sparsity_csr.hpp
@@ -2,6 +2,7 @@
 
 #include <ctldl/sparsity/get_entries_csr.hpp>
 #include <ctldl/sparsity/sparsity.hpp>
+#include <ctldl/utility/static_sized_range.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -63,7 +64,8 @@ constexpr auto makeSparsityStaticCSR(const SparsityIn& sparsity) {
   return SparsityStaticCSR{makeSparsityStatic(sparsity)};
 }
 
-template <std::size_t num_rows, std::size_t num_cols, class Entries>
+template <std::size_t num_rows, std::size_t num_cols,
+          static_sized_range Entries>
 constexpr auto makeSparsityStaticCSR(const Entries& entries) {
   return SparsityStaticCSR{makeSparsityStatic<num_rows, num_cols>(entries)};
 }

--- a/ctldl/utility/static_sized_range.hpp
+++ b/ctldl/utility/static_sized_range.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <ranges>
+#include <type_traits>
+
+namespace ctldl {
+
+template <class T>
+struct range_static_size;
+
+template <class T, std::size_t n>
+struct range_static_size<std::array<T, n>>
+    : std::integral_constant<std::size_t, n> {};
+
+template <class T, std::size_t n>
+struct range_static_size<T[n]> : std::integral_constant<std::size_t, n> {};
+
+template <class T>
+inline constexpr std::size_t range_static_size_v = range_static_size<T>::value;
+
+template <class T>
+concept static_sized_range = std::ranges::sized_range<T> && requires {
+  std::integral_constant<std::size_t, range_static_size_v<T>>{};
+};
+
+}  // namespace ctldl


### PR DESCRIPTION
Only works if size of range is known at compile-time. P3928R0 would be nice but for now let's just manually support the few types we use.