### PR TITLE
Simplify fill-in functions

### DIFF
--- a/ctldl/factor_data/factorization.hpp
+++ b/ctldl/factor_data/factorization.hpp
@@ -59,7 +59,7 @@ class Factorization {
   }
 
   static constexpr auto sparsity =
-      SparsityStaticCSR(getFilledInSparsity<sparsity_orig, permutation>());
+      defineStaticSparsityCSR(getFilledInSparsity(sparsity_orig, permutation));
   static constexpr auto nnz = std::size_t{sparsity.nnz()};
   static constexpr auto permutation_row = permutation;
   static constexpr auto permutation_col = permutation;

--- a/ctldl/factor_data/factorization_already_permuted.hpp
+++ b/ctldl/factor_data/factorization_already_permuted.hpp
@@ -15,8 +15,9 @@ namespace ctldl {
 // remember the correct permutation within Factorization.
 template <SparsityStatic sparsity, class Value, PermutationStatic permutation>
 using FactorizationAlreadyPermuted =
-    Factorization<getSparsityStaticLowerTriangle<sparsity>(
-                      invertPermutation(permutation)),
+    Factorization<([:reflectSparsityStatic(
+                         defineStaticSparsity(getSparsityDynamicLowerTriangle(
+                             sparsity, invertPermutation(permutation)))):]),
                   Value, permutation>;
 
 }  // namespace ctldl

--- a/ctldl/factor_data/factorization_repeating_block_tridiagonal_arrowhead_linked.hpp
+++ b/ctldl/factor_data/factorization_repeating_block_tridiagonal_arrowhead_linked.hpp
@@ -48,37 +48,38 @@ class FactorizationRepeatingBlockTridiagonalArrowheadLinked {
   static constexpr auto permutation_link = sparsity.link.permutation;
   static constexpr auto permutation_outer = sparsity.outer.permutation;
 
-  static constexpr auto helper_start = getFilledInSparsityBlocked3x3<
-      sparsity.start.diag, sparsity.start.next, sparsity.tridiag.diag,
-      sparsity.start.outer, sparsity.outer.subdiag, sparsity.outer.diag,
-      permutation_start, permutation_tridiag, permutation_outer>();
+  static constexpr auto helper_start =
+      defineStaticSparsity(getFilledInSparsityBlocked3x3(
+          sparsity.start.diag, sparsity.start.next, sparsity.tridiag.diag,
+          sparsity.start.outer, sparsity.outer.subdiag, sparsity.outer.diag,
+          permutation_start, permutation_tridiag, permutation_outer));
   static constexpr auto sparsity_factor_start_diag = helper_start.block11;
   static constexpr auto sparsity_factor_start_tridiag = helper_start.block21;
   static constexpr auto sparsity_factor_start_outer = helper_start.block31;
   static constexpr auto sparsity_tridiag_diag = helper_start.block22;
-  static constexpr auto sparsity_tridiag_subdiag = getSparsityStaticPermuted(
-      sparsity.tridiag.subdiag, permutation_tridiag, permutation_tridiag);
+  static constexpr auto sparsity_tridiag_subdiag =
+      defineStaticSparsity(getSparsityDynamicPermuted(
+          sparsity.tridiag.subdiag, permutation_tridiag, permutation_tridiag));
   static constexpr auto sparsity_outer_subdiag = helper_start.block32;
   static constexpr auto sparsity_outer_diag = helper_start.block33;
 
-  static constexpr auto sparsity_factor = getFilledInSparsityRepeatingArrowhead<
-      sparsity_tridiag_diag, sparsity_tridiag_subdiag, sparsity_outer_subdiag,
-      PermutationStatic<dim_tridiag>{}, PermutationStatic<dim_outer>{}>();
+  static constexpr auto sparsity_factor =
+      defineStaticSparsity(getFilledInSparsityRepeatingArrowhead(
+          sparsity_tridiag_diag, sparsity_tridiag_subdiag,
+          sparsity_outer_subdiag, PermutationStatic<dim_tridiag>{},
+          PermutationStatic<dim_outer>{}));
 
   static constexpr auto helper = [] {
-    constexpr auto sparsity_link_tridiag_permuted_cols =
-        getSparsityStaticPermuted(sparsity.link.prev,
-                                  PermutationStatic<dim_link>{},
-                                  permutation_tridiag);
-    constexpr auto sparsity_link_outer_permuted_rows =
-        getSparsityStaticPermuted(sparsity.link.next, permutation_outer,
-                                  PermutationStatic<dim_link>{});
-    return getFilledInSparsityBlocked3x3<
+    const auto sparsity_link_tridiag_permuted_cols = getSparsityDynamicPermuted(
+        sparsity.link.prev, PermutationStatic<dim_link>{}, permutation_tridiag);
+    const auto sparsity_link_outer_permuted_rows = getSparsityDynamicPermuted(
+        sparsity.link.next, permutation_outer, PermutationStatic<dim_link>{});
+    return defineStaticSparsity(getFilledInSparsityBlocked3x3(
         sparsity_factor.diag, sparsity_link_tridiag_permuted_cols,
         sparsity.link.diag, sparsity_factor.outer,
         sparsity_link_outer_permuted_rows, sparsity_outer_diag,
         PermutationStatic<dim_tridiag>{}, permutation_link,
-        PermutationStatic<dim_outer>{}>();
+        PermutationStatic<dim_outer>{}));
   }();
   static constexpr auto sparsity_factor_link_tridiag = helper.block21;
   static constexpr auto sparsity_factor_link_diag = helper.block22;
@@ -87,35 +88,36 @@ class FactorizationRepeatingBlockTridiagonalArrowheadLinked {
 
  public:
   using Value = Value_;
-  using FactorStartDiag =
-      FactorizationAlreadyPermuted<sparsity_factor_start_diag, Value,
-                                   permutation_start>;
-  using FactorStartTridiag =
-      FactorizationSubdiagonalBlock<sparsity_factor_start_tridiag, Value,
-                                    permutation_tridiag, permutation_start>;
-  using FactorStartOuter =
-      FactorizationSubdiagonalBlock<sparsity_factor_start_outer, Value,
-                                    permutation_outer, permutation_start>;
-  using FactorTridiagDiag =
-      FactorizationAlreadyPermuted<sparsity_factor.diag, Value,
-                                   permutation_tridiag>;
-  using FactorTridiagSubdiag =
-      FactorizationSubdiagonalBlock<sparsity_factor.subdiag, Value,
-                                    permutation_tridiag, permutation_tridiag>;
-  using FactorLinkTridiag =
-      FactorizationSubdiagonalBlock<sparsity_factor_link_tridiag, Value,
-                                    permutation_link, permutation_tridiag>;
-  using FactorLinkDiag = FactorizationAlreadyPermuted<sparsity_factor_link_diag,
-                                                      Value, permutation_link>;
-  using FactorLinkOuter =
-      FactorizationSubdiagonalBlock<sparsity_factor_link_outer, Value,
-                                    permutation_outer, permutation_link>;
-  using FactorOuterSubdiag =
-      FactorizationSubdiagonalBlock<sparsity_factor.outer, Value,
-                                    permutation_outer, permutation_tridiag>;
-  using FactorOuterDiag =
-      FactorizationAlreadyPermuted<sparsity_factor_outer_diag, Value,
-                                   permutation_outer>;
+  using FactorStartDiag = FactorizationAlreadyPermuted<
+      ([:reflectSparsityStatic(sparsity_factor_start_diag):]), Value,
+      permutation_start>;
+  using FactorStartTridiag = FactorizationSubdiagonalBlock<
+      ([:reflectSparsityStatic(sparsity_factor_start_tridiag):]), Value,
+      permutation_tridiag, permutation_start>;
+  using FactorStartOuter = FactorizationSubdiagonalBlock<
+      ([:reflectSparsityStatic(sparsity_factor_start_outer):]), Value,
+      permutation_outer, permutation_start>;
+  using FactorTridiagDiag = FactorizationAlreadyPermuted<
+      ([:reflectSparsityStatic(sparsity_factor.diag):]), Value,
+      permutation_tridiag>;
+  using FactorTridiagSubdiag = FactorizationSubdiagonalBlock<
+      ([:reflectSparsityStatic(sparsity_factor.subdiag):]), Value,
+      permutation_tridiag, permutation_tridiag>;
+  using FactorLinkTridiag = FactorizationSubdiagonalBlock<
+      ([:reflectSparsityStatic(sparsity_factor_link_tridiag):]), Value,
+      permutation_link, permutation_tridiag>;
+  using FactorLinkDiag = FactorizationAlreadyPermuted<
+      ([:reflectSparsityStatic(sparsity_factor_link_diag):]), Value,
+      permutation_link>;
+  using FactorLinkOuter = FactorizationSubdiagonalBlock<
+      ([:reflectSparsityStatic(sparsity_factor_link_outer):]), Value,
+      permutation_outer, permutation_link>;
+  using FactorOuterSubdiag = FactorizationSubdiagonalBlock<
+      ([:reflectSparsityStatic(sparsity_factor.outer):]), Value,
+      permutation_outer, permutation_tridiag>;
+  using FactorOuterDiag = FactorizationAlreadyPermuted<
+      ([:reflectSparsityStatic(sparsity_factor_outer_diag):]), Value,
+      permutation_outer>;
 
   using FactorStart =
       MatrixStart<FactorStartDiag, FactorStartTridiag, FactorStartOuter>;

--- a/ctldl/sparsity/sparsity.hpp
+++ b/ctldl/sparsity/sparsity.hpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <concepts>
 #include <cstddef>
+#include <meta>
 #include <ranges>
 #include <span>
 #include <vector>
@@ -148,10 +149,48 @@ class SparsityView {
   constexpr std::size_t numCols() const { return m_num_cols; }
   constexpr std::size_t nnz() const { return m_entries.size(); }
 
+ protected:
+  constexpr SparsityView(const std::size_t num_rows, const std::size_t num_cols,
+                         const std::span<const Entry> entries)
+      : m_entries(entries), m_num_rows(num_rows), m_num_cols(num_cols) {
+    pre(std::ranges::all_of(entries, [num_rows, num_cols](const auto entry) {
+      return entry.row_index < num_rows && entry.col_index < num_cols;
+    }));
+  }
+
+  friend consteval auto defineStaticSparsity(const SparsityView sparsity);
+
  private:
   std::span<const Entry> m_entries;
   std::size_t m_num_rows;
   std::size_t m_num_cols;
 };
+
+consteval auto defineStaticSparsity(const SparsityView sparsity) {
+  const auto entries = std::define_static_array(sparsity.entries());
+  return SparsityView(sparsity.numRows(), sparsity.numCols(), entries);
+}
+
+namespace detail {
+
+template <std::size_t num_rows, std::size_t num_cols, std::size_t nnz,
+          const Entry* data>
+inline constexpr auto sparsity_static_helper_to_reflect_on =
+    makeSparsityStatic<num_rows, num_cols>(
+        std::span<const Entry, nnz>(data, nnz));
+
+}  // namespace detail
+
+consteval auto reflectSparsityStatic(const SparsityView sparsity) {
+  const std::meta::info num_rows =
+      std::meta::reflect_constant(sparsity.numRows());
+  const std::meta::info num_cols =
+      std::meta::reflect_constant(sparsity.numCols());
+  const std::meta::info nnz = std::meta::reflect_constant(sparsity.nnz());
+  const std::meta::info data =
+      std::meta::reflect_constant(sparsity.entries().data());
+  return std::meta::substitute(^^detail::sparsity_static_helper_to_reflect_on,
+                               {num_rows, num_cols, nnz, data});
+}
 
 }  // namespace ctldl

--- a/ctldl/sparsity/sparsity_csr.hpp
+++ b/ctldl/sparsity/sparsity_csr.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <meta>
 #include <span>
 
 namespace ctldl {
@@ -142,6 +143,17 @@ class SparsityViewCSR : public SparsityView {
  private:
   std::span<const std::size_t> m_row_begin_indices;
 
+  constexpr SparsityViewCSR(
+      const std::size_t num_rows, const std::size_t num_cols,
+      const std::span<const Entry> entries,
+      const std::span<const std::size_t> row_begin_indices)
+      : SparsityView(num_rows, num_cols, entries),
+        m_row_begin_indices(row_begin_indices) {
+    // TODO: even if we trust our friends, check invariants
+  }
+
+  friend consteval auto defineStaticSparsityCSR(const SparsityViewCSR sparsity);
+
  public:
   constexpr SparsityViewCSR(const SparsityDynamicCSR& sparsity)
       : SparsityView(sparsity),
@@ -177,5 +189,19 @@ class SparsityViewCSR : public SparsityView {
     return static_cast<std::size_t>(find(i, j) - std::cbegin(rowView(0)));
   }
 };
+
+consteval auto defineStaticSparsityCSR(const SparsityViewCSR sparsity) {
+  const auto entries = std::define_static_array(sparsity.entries());
+  const auto row_begin_indices =
+      std::define_static_array(sparsity.rowBeginIndices());
+  return SparsityViewCSR(sparsity.numRows(), sparsity.numCols(), entries,
+                         row_begin_indices);
+}
+
+consteval auto defineStaticSparsityCSR(const SparsityView sparsity) {
+  return defineStaticSparsityCSR(
+      SparsityViewCSR(SparsityDynamicCSR(SparsityDynamic(
+          sparsity.numRows(), sparsity.numCols(), sparsity.entries()))));
+}
 
 }  // namespace ctldl

--- a/ctldl/sparsity/sparsity_lower_triangle.hpp
+++ b/ctldl/sparsity/sparsity_lower_triangle.hpp
@@ -4,10 +4,8 @@
 #include <ctldl/permutation/permuted_entry_lower_triangle.hpp>
 #include <ctldl/sparsity/entry.hpp>
 #include <ctldl/sparsity/is_square.hpp>
-#include <ctldl/utility/fix_init_if_zero_length_array.hpp>
 #include <ctldl/utility/contracts.hpp>
 
-#include <array>
 #include <cstddef>
 #include <vector>
 
@@ -45,17 +43,6 @@ constexpr auto getSparsityDynamicLowerTriangle(
   pre(isSquare(sparsity));
   return SparsityDynamic(sparsity.numRows(), sparsity.numCols(),
                          getEntriesLowerTriangle(sparsity, permutation));
-}
-
-template <SparsityStatic sparsity>
-constexpr auto getSparsityStaticLowerTriangle(
-    const PermutationView permutation) {
-  constexpr auto nnz = getNnzLowerTriangle(sparsity);
-  std::array<Entry, nnz> entries;
-  fixInitIfZeroLengthArray(entries);
-  std::ranges::copy(getEntriesLowerTriangle(sparsity, permutation),
-                    entries.begin());
-  return SparsityStatic<nnz, sparsity.numRows(), sparsity.numCols()>(entries);
 }
 
 }  // namespace ctldl

--- a/ctldl/sparsity/sparsity_permuted.hpp
+++ b/ctldl/sparsity/sparsity_permuted.hpp
@@ -5,7 +5,6 @@
 #include <ctldl/sparsity/entry.hpp>
 #include <ctldl/sparsity/sparsity.hpp>
 
-#include <array>
 #include <ranges>
 #include <vector>
 
@@ -33,21 +32,6 @@ constexpr auto getSparsityDynamicPermuted(
   return SparsityDynamic(
       sparsity.numRows(), sparsity.numCols(),
       getEntriesPermuted(sparsity, permutation_row, permutation_col));
-}
-
-template <class SparsityIn>
-constexpr auto getSparsityStaticPermuted(
-    const SparsityIn& sparsity, const PermutationView permutation_row,
-    const PermutationView permutation_col) {
-  using std::size;
-  constexpr auto nnz = std::size_t{size(decltype(sparsity.entries()){})};
-
-  std::array<Entry, nnz> entries;
-  std::ranges::copy(
-      getEntriesPermuted(sparsity, permutation_row, permutation_col),
-      entries.begin());
-  return SparsityStatic<nnz, SparsityIn::numRows(), SparsityIn::numCols()>(
-      entries);
 }
 
 }  // namespace ctldl

--- a/ctldl/symbolic/filled_in_sparsity.hpp
+++ b/ctldl/symbolic/filled_in_sparsity.hpp
@@ -5,19 +5,21 @@
 #include <ctldl/sparsity/sparsity_csr.hpp>
 #include <ctldl/sparsity/sparsity_lower_triangle.hpp>
 #include <ctldl/symbolic/get_entries_with_fill.hpp>
+#include <ctldl/utility/contracts.hpp>
 
 #include <cstddef>
 
 namespace ctldl {
 
-template <auto sparsity,
-          auto permutation = PermutationStatic<sparsity.numRows()>{}>
-constexpr auto getFilledInSparsity() {
-  static_assert(isSquare(sparsity));
-  constexpr auto dim = std::size_t{sparsity.numRows()};
-  return makeSparsityStatic<dim, dim>(
-      getEntriesWithFill<SparsityStaticCSR(
-          getSparsityStaticLowerTriangle<sparsity>(permutation))>());
+constexpr auto getFilledInSparsity(const SparsityView sparsity,
+                                   const PermutationView permutation) {
+  pre(isSquare(sparsity));
+  pre(permutation.size() == sparsity.numRows());
+  const auto dim = std::size_t{sparsity.numRows()};
+  return SparsityDynamic(
+      dim, dim,
+      getEntriesWithFill(SparsityDynamicCSR(
+          getSparsityDynamicLowerTriangle(sparsity, permutation))));
 }
 
 }  // namespace ctldl

--- a/ctldl/symbolic/filled_in_sparsity_blocked.hpp
+++ b/ctldl/symbolic/filled_in_sparsity_blocked.hpp
@@ -11,121 +11,64 @@
 #include <ctldl/symbolic/foreach_nonzero_with_fill_blocked.hpp>
 #include <ctldl/symbolic/lower_triangle_blocked.hpp>
 
-#include <array>
 #include <cstddef>
+#include <vector>
 
 namespace ctldl {
 
-constexpr auto getFilledInNumNonZerosBlocked3x3(
-    const SparsityViewCSR sparsity11, const SparsityViewCSR sparsity21,
-    const SparsityViewCSR sparsity22, const SparsityViewCSR sparsity31,
-    const SparsityViewCSR sparsity32, const SparsityViewCSR sparsity33) {
-  LowerTriangleBlocked3x3 nnz{std::size_t{0}, std::size_t{0}, std::size_t{0},
-                              std::size_t{0}, std::size_t{0}, std::size_t{0}};
-  const auto count_nonzero = [&](const std::size_t i, const std::size_t j) {
-    if (j < sparsity11.numCols()) {
-      if (i < sparsity11.numRows()) {
-        nnz.block11 += 1;
-      } else if (i < sparsity11.numRows() + sparsity22.numRows()) {
-        nnz.block21 += 1;
-      } else {
-        nnz.block31 += 1;
-      }
-    } else if (j < sparsity11.numCols() + sparsity22.numCols()) {
-      if (i < sparsity11.numRows() + sparsity22.numRows()) {
-        nnz.block22 += 1;
-      } else {
-        nnz.block32 += 1;
-      }
-    } else {
-      nnz.block33 += 1;
-    }
-  };
-  foreachNonZeroWithFillBlocked3x3(sparsity11, sparsity21, sparsity22,
-                                   sparsity31, sparsity32, sparsity33,
-                                   count_nonzero);
-  return nnz;
-}
+constexpr auto getFilledInSparsityBlocked3x3(
+    const SparsityView sparsity11_in, const SparsityView sparsity21_in,
+    const SparsityView sparsity22_in, const SparsityView sparsity31_in,
+    const SparsityView sparsity32_in, const SparsityView sparsity33_in,
+    const PermutationView permutation1, const PermutationView permutation2,
+    const PermutationView permutation3) {
+  pre(isSquare(sparsity11_in));
+  pre(isSquare(sparsity22_in));
+  pre(sparsity21_in.numCols() == sparsity11_in.numCols());
+  pre(sparsity22_in.numRows() == sparsity21_in.numRows());
 
-constexpr auto getFilledInNumNonZerosBlocked(const SparsityViewCSR sparsity11,
-                                             const SparsityViewCSR sparsity21,
-                                             const SparsityViewCSR sparsity22) {
-  const auto sparsity31_dummy =
-      makeEmptySparsityDynamicCSR(0, sparsity11.numCols());
-  const auto sparsity32_dummy =
-      makeEmptySparsityDynamicCSR(0, sparsity22.numCols());
-  const auto sparsity33_dummy = makeEmptySparsityDynamicCSR(0, 0);
-  const auto nnz = getFilledInNumNonZerosBlocked3x3(
-      sparsity11, sparsity21, sparsity22, sparsity31_dummy, sparsity32_dummy,
-      sparsity33_dummy);
-  return LowerTriangleBlocked{nnz.block11, nnz.block21, nnz.block22};
-}
+  const auto sparsity11 = SparsityDynamicCSR(
+      getSparsityDynamicLowerTriangle(sparsity11_in, permutation1));
+  const auto sparsity21 = SparsityDynamicCSR(
+      getSparsityDynamicPermuted(sparsity21_in, permutation2, permutation1));
+  const auto sparsity22 = SparsityDynamicCSR(
+      getSparsityDynamicLowerTriangle(sparsity22_in, permutation2));
+  const auto sparsity31 = SparsityDynamicCSR(
+      getSparsityDynamicPermuted(sparsity31_in, permutation3, permutation1));
+  const auto sparsity32 = SparsityDynamicCSR(
+      getSparsityDynamicPermuted(sparsity32_in, permutation3, permutation2));
+  const auto sparsity33 = SparsityDynamicCSR(
+      getSparsityDynamicLowerTriangle(sparsity33_in, permutation3));
 
-template <auto sparsity11_in, auto sparsity21_in, auto sparsity22_in,
-          auto sparsity31_in, auto sparsity32_in, auto sparsity33_in,
-          auto permutation1 = PermutationStatic<sparsity11_in.numRows()>(),
-          auto permutation2 = PermutationStatic<sparsity22_in.numRows()>(),
-          auto permutation3 = PermutationStatic<sparsity33_in.numRows()>()>
-constexpr auto getFilledInSparsityBlocked3x3() {
-  static_assert(isSquare(sparsity11_in));
-  static_assert(isSquare(sparsity22_in));
-  static_assert(sparsity21_in.numCols() == sparsity11_in.numCols());
-  static_assert(sparsity22_in.numRows() == sparsity21_in.numRows());
-
-  constexpr auto sparsity11 = SparsityStaticCSR(
-      getSparsityStaticLowerTriangle<sparsity11_in>(permutation1));
-  constexpr auto sparsity21 = SparsityStaticCSR(
-      getSparsityStaticPermuted(sparsity21_in, permutation2, permutation1));
-  constexpr auto sparsity22 = SparsityStaticCSR(
-      getSparsityStaticLowerTriangle<sparsity22_in>(permutation2));
-  constexpr auto sparsity31 = SparsityStaticCSR(
-      getSparsityStaticPermuted(sparsity31_in, permutation3, permutation1));
-  constexpr auto sparsity32 = SparsityStaticCSR(
-      getSparsityStaticPermuted(sparsity32_in, permutation3, permutation2));
-  constexpr auto sparsity33 = SparsityStaticCSR(
-      getSparsityStaticLowerTriangle<sparsity33_in>(permutation3));
-
-  constexpr auto nnz = getFilledInNumNonZerosBlocked3x3(
-      sparsity11, sparsity21, sparsity22, sparsity31, sparsity32, sparsity33);
-
-  std::array<Entry, nnz.block11> entries11;
-  std::array<Entry, nnz.block21> entries21;
-  std::array<Entry, nnz.block22> entries22;
-  std::array<Entry, nnz.block31> entries31;
-  std::array<Entry, nnz.block32> entries32;
-  std::array<Entry, nnz.block33> entries33;
-  LowerTriangleBlocked3x3 entry_index{std::size_t{0}, std::size_t{0},
-                                      std::size_t{0}, std::size_t{0},
-                                      std::size_t{0}, std::size_t{0}};
+  std::vector<Entry> entries11;
+  std::vector<Entry> entries21;
+  std::vector<Entry> entries22;
+  std::vector<Entry> entries31;
+  std::vector<Entry> entries32;
+  std::vector<Entry> entries33;
   const auto add_nonzero = [&](const std::size_t i, const std::size_t j) {
     if (j < sparsity11.numCols()) {
       if (i < sparsity11.numRows()) {
-        entries11[entry_index.block11] = Entry{i, j};
-        entry_index.block11 += 1;
+        entries11.push_back(Entry{i, j});
       } else if (i < sparsity11.numRows() + sparsity22.numRows()) {
-        entries21[entry_index.block21] = Entry{i - sparsity11.numRows(), j};
-        entry_index.block21 += 1;
+        entries21.push_back(Entry{i - sparsity11.numRows(), j});
       } else {
-        entries31[entry_index.block31] =
-            Entry{i - sparsity11.numRows() - sparsity22.numRows(), j};
-        entry_index.block31 += 1;
+        entries31.push_back(
+            Entry{i - sparsity11.numRows() - sparsity22.numRows(), j});
       }
     } else if (j < sparsity11.numCols() + sparsity22.numCols()) {
       if (i < sparsity11.numRows() + sparsity22.numRows()) {
-        entries22[entry_index.block22] =
-            Entry{i - sparsity11.numRows(), j - sparsity11.numCols()};
-        entry_index.block22 += 1;
+        entries22.push_back(
+            Entry{i - sparsity11.numRows(), j - sparsity11.numCols()});
       } else {
-        entries32[entry_index.block32] =
+        entries32.push_back(
             Entry{i - sparsity11.numRows() - sparsity22.numRows(),
-                  j - sparsity11.numCols()};
-        entry_index.block32 += 1;
+                  j - sparsity11.numCols()});
       }
     } else {
-      entries33[entry_index.block33] =
+      entries33.push_back(
           Entry{i - sparsity11.numRows() - sparsity22.numRows(),
-                j - sparsity11.numCols() - sparsity22.numCols()};
-      entry_index.block33 += 1;
+                j - sparsity11.numCols() - sparsity22.numCols()});
     }
   };
 
@@ -141,30 +84,38 @@ constexpr auto getFilledInSparsityBlocked3x3() {
   sortEntriesRowMajorSorted(entries33);
 
   return LowerTriangleBlocked3x3{
-      makeSparsityStatic<sparsity11.numRows(), sparsity11.numCols()>(entries11),
-      makeSparsityStatic<sparsity21.numRows(), sparsity21.numCols()>(entries21),
-      makeSparsityStatic<sparsity22.numRows(), sparsity22.numCols()>(entries22),
-      makeSparsityStatic<sparsity31.numRows(), sparsity31.numCols()>(entries31),
-      makeSparsityStatic<sparsity32.numRows(), sparsity32.numCols()>(entries32),
-      makeSparsityStatic<sparsity33.numRows(), sparsity33.numCols()>(
-          entries33)};
+      SparsityDynamic(sparsity11.numRows(), sparsity11.numCols(), entries11),
+      SparsityDynamic(sparsity21.numRows(), sparsity21.numCols(), entries21),
+      SparsityDynamic(sparsity22.numRows(), sparsity22.numCols(), entries22),
+      SparsityDynamic(sparsity31.numRows(), sparsity31.numCols(), entries31),
+      SparsityDynamic(sparsity32.numRows(), sparsity32.numCols(), entries32),
+      SparsityDynamic(sparsity33.numRows(), sparsity33.numCols(), entries33)};
 }
 
-template <auto sparsity11, auto sparsity21, auto sparsity22,
-          auto permutation1 = PermutationStatic<sparsity11.numRows()>(),
-          auto permutation2 = PermutationStatic<sparsity22.numRows()>()>
-constexpr auto getFilledInSparsityBlocked() {
-  constexpr auto sparsity31_dummy =
-      makeEmptySparsityStatic<0, sparsity11.numCols()>();
-  constexpr auto sparsity32_dummy =
-      makeEmptySparsityStatic<0, sparsity22.numCols()>();
-  constexpr auto sparsity33_dummy = makeEmptySparsityStatic<0, 0>();
-  constexpr auto permutation3_dummy = PermutationStatic<0>{};
-  const auto sparsity = getFilledInSparsityBlocked3x3<
+constexpr auto getFilledInSparsityBlocked(const SparsityView sparsity11,
+                                          const SparsityView sparsity21,
+                                          const SparsityView sparsity22,
+                                          const PermutationView permutation1,
+                                          const PermutationView permutation2) {
+  const auto sparsity31_dummy =
+      makeEmptySparsityDynamic(0, sparsity11.numCols());
+  const auto sparsity32_dummy =
+      makeEmptySparsityDynamic(0, sparsity22.numCols());
+  const auto sparsity33_dummy = makeEmptySparsityDynamic(0, 0);
+  const auto permutation3_dummy = PermutationDynamic(0);
+  const auto sparsity = getFilledInSparsityBlocked3x3(
       sparsity11, sparsity21, sparsity22, sparsity31_dummy, sparsity32_dummy,
-      sparsity33_dummy, permutation1, permutation2, permutation3_dummy>();
+      sparsity33_dummy, permutation1, permutation2, permutation3_dummy);
   return LowerTriangleBlocked{sparsity.block11, sparsity.block21,
                               sparsity.block22};
+}
+
+constexpr auto getFilledInSparsityBlocked(const SparsityView sparsity11,
+                                          const SparsityView sparsity21,
+                                          const SparsityView sparsity22) {
+  return getFilledInSparsityBlocked(sparsity11, sparsity21, sparsity22,
+                                    PermutationDynamic(sparsity11.numRows()),
+                                    PermutationDynamic(sparsity22.numRows()));
 }
 
 }  // namespace ctldl

--- a/ctldl/symbolic/filled_in_sparsity_blocked.test.cpp
+++ b/ctldl/symbolic/filled_in_sparsity_blocked.test.cpp
@@ -13,7 +13,7 @@ namespace {
 
 BOOST_AUTO_TEST_CASE(FilledInSparsityBlockedEmptyTest) {
   constexpr auto empty = makeEmptySparsityStatic<1, 1>();
-  constexpr auto filled = getFilledInSparsityBlocked<empty, empty, empty>();
+  constexpr auto filled = getFilledInSparsityBlocked(empty, empty, empty);
   CTLDL_TEST_SPARSITY_EQUAL(filled.block11, empty);
   CTLDL_TEST_SPARSITY_EQUAL(filled.block21, empty);
   CTLDL_TEST_SPARSITY_EQUAL(filled.block22, empty);
@@ -25,14 +25,15 @@ BOOST_AUTO_TEST_CASE(FilledInSparsityBlockedNos2Test) {
       makeSparsityStatic<3, 3>({{0, 0}, {1, 1}, {1, 2}, {2, 1}, {2, 2}});
   constexpr auto sparsity22 = sparsity11;
 
-  constexpr auto filled =
-      getFilledInSparsityBlocked<sparsity11, sparsity21, sparsity22>();
+  constexpr auto filled = defineStaticSparsity(
+      getFilledInSparsityBlocked(sparsity11, sparsity21, sparsity22));
 
-  constexpr auto expected = LowerTriangleBlocked{
-      sparsity11, sparsity21, makeSparsityStatic<3, 3>({{2, 1}})};
-  CTLDL_TEST_SPARSITY_EQUAL(filled.block11, expected.block11);
-  CTLDL_TEST_SPARSITY_EQUAL(filled.block21, expected.block21);
-  CTLDL_TEST_SPARSITY_EQUAL(filled.block22, expected.block22);
+  constexpr auto expected11 = sparsity11;
+  constexpr auto expected21 = sparsity21;
+  constexpr auto expected22 = makeSparsityStatic<3, 3>({{2, 1}});
+  CTLDL_TEST_SPARSITY_EQUAL(filled.block11, expected11);
+  CTLDL_TEST_SPARSITY_EQUAL(filled.block21, expected21);
+  CTLDL_TEST_SPARSITY_EQUAL(filled.block22, expected22);
 }
 
 }  // anonymous namespace

--- a/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.hpp
+++ b/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.hpp
@@ -11,93 +11,44 @@
 #include <ctldl/symbolic/repeating_block_tridiagonal_arrowhead.hpp>
 #include <ctldl/utility/contracts.hpp>
 
-#include <array>
 #include <cstddef>
+#include <vector>
 
 namespace ctldl {
 
-constexpr auto getNumNonZerosWithFillRepeatingArrowhead(
-    const SparsityViewCSR sparsity_A, const SparsityViewCSR sparsity_B,
-    const SparsityViewCSR sparsity_C) {
-  pre(isSquare(sparsity_A));
-  pre(isSquare(sparsity_B));
-  pre(sparsity_A.numRows() == sparsity_B.numRows());
-  const auto dim = std::size_t{sparsity_A.numRows()};
-  pre(sparsity_C.numCols() == sparsity_A.numCols());
-  RepeatingBlockTridiagonalArrowhead nnz{std::size_t{0}, std::size_t{0},
-                                         std::size_t{0}};
-  const auto count_nonzero = [dim, &nnz](const std::size_t i,
-                                         const std::size_t j) {
+constexpr auto getFilledInSparsityRepeatingArrowhead(
+    const SparsityView sparsity_in_A, const SparsityView sparsity_in_B,
+    const SparsityView sparsity_in_C, const PermutationView permutation,
+    const PermutationView permutation_C) {
+  pre(isSquare(sparsity_in_A));
+  pre(isSquare(sparsity_in_B));
+  pre(sparsity_in_B.numRows() == sparsity_in_A.numRows());
+  pre(sparsity_in_C.numCols() == sparsity_in_A.numCols());
+  const auto dim = std::size_t{sparsity_in_A.numRows()};
+  const auto dim_outer = std::size_t{sparsity_in_C.numRows()};
+
+  const auto sparsity_A = SparsityDynamicCSR(
+      getSparsityDynamicLowerTriangle(sparsity_in_A, permutation));
+  const auto sparsity_B = SparsityDynamicCSR(
+      getSparsityDynamicPermuted(sparsity_in_B, permutation, permutation));
+  const auto sparsity_C = SparsityDynamicCSR(
+      getSparsityDynamicPermuted(sparsity_in_C, permutation_C, permutation));
+
+  RepeatingBlockTridiagonalArrowhead entries{
+      std::vector<Entry>{}, std::vector<Entry>{},
+      std::vector<Entry>{}};
+  const auto add_nonzero = [dim, &entries](const std::size_t i,
+                                           const std::size_t j) {
     if (i >= 2 * dim) {
-      nnz.outer += 1;
+      entries.outer.push_back(Entry{i - 2 * dim, j % dim});
     } else {
       if (j >= dim) {
-        nnz.diag += 1;
+        entries.diag.push_back(Entry{i - dim, j - dim});
       } else {
-        nnz.subdiag += 1;
+        entries.subdiag.push_back(Entry{i - dim, j});
       }
     }
   };
-  foreachNonZeroWithFillRepeatingArrowhead(sparsity_A, sparsity_B, sparsity_C,
-                                           count_nonzero);
-  return nnz;
-}
-
-struct EntryAdderRepeatingBlockTridiagonalArrowhead {
-  std::size_t dim;
-  RepeatingBlockTridiagonalArrowhead<std::span<Entry>, std::span<Entry>,
-                                     std::span<Entry>>
-      entries;
-  RepeatingBlockTridiagonalArrowhead<std::size_t, std::size_t, std::size_t>&
-      entry_index;
-
-  constexpr void operator()(const std::size_t i, const std::size_t j) const {
-    if (i >= 2 * dim) {
-      entries.outer[entry_index.outer] = Entry{i - 2 * dim, j % dim};
-      entry_index.outer += 1;
-    } else {
-      if (j >= dim) {
-        entries.diag[entry_index.diag] = Entry{i - dim, j - dim};
-        entry_index.diag += 1;
-      } else {
-        entries.subdiag[entry_index.subdiag] = Entry{i - dim, j};
-        entry_index.subdiag += 1;
-      }
-    }
-  }
-};
-
-template <auto sparsity_in_A, auto sparsity_in_B, auto sparsity_in_C,
-          auto permutation, auto permutation_C>
-constexpr auto getFilledInSparsityRepeatingArrowhead() {
-  static_assert(isSquare(sparsity_in_A));
-  static_assert(isSquare(sparsity_in_B));
-  static_assert(sparsity_in_B.numRows() == sparsity_in_A.numRows());
-  static_assert(sparsity_in_C.numCols() == sparsity_in_A.numCols());
-  constexpr auto dim = std::size_t{sparsity_in_A.numRows()};
-  constexpr auto dim_outer = std::size_t{sparsity_in_C.numRows()};
-
-  constexpr auto sparsity_A = SparsityStaticCSR(
-      getSparsityStaticLowerTriangle<sparsity_in_A>(permutation));
-  constexpr auto sparsity_B = SparsityStaticCSR(
-      getSparsityStaticPermuted(sparsity_in_B, permutation, permutation));
-  constexpr auto sparsity_C = SparsityStaticCSR(
-      getSparsityStaticPermuted(sparsity_in_C, permutation_C, permutation));
-
-  constexpr auto nnz = getNumNonZerosWithFillRepeatingArrowhead(
-      sparsity_A, sparsity_B, sparsity_C);
-
-  RepeatingBlockTridiagonalArrowhead entries{
-      std::array<Entry, nnz.diag>{}, std::array<Entry, nnz.subdiag>{},
-      std::array<Entry, nnz.outer>{}};
-  RepeatingBlockTridiagonalArrowhead entry_index{std::size_t{0}, std::size_t{0},
-                                                 std::size_t{0}};
-  const EntryAdderRepeatingBlockTridiagonalArrowhead add_nonzero{
-      dim,
-      RepeatingBlockTridiagonalArrowhead{std::span<Entry>{entries.diag},
-                                         std::span<Entry>{entries.subdiag},
-                                         std::span<Entry>{entries.outer}},
-      entry_index};
   foreachNonZeroWithFillRepeatingArrowhead(sparsity_A, sparsity_B, sparsity_C,
                                            add_nonzero);
 
@@ -107,9 +58,9 @@ constexpr auto getFilledInSparsityRepeatingArrowhead() {
   sortEntriesRowMajorSorted(entries.outer);
 
   return RepeatingBlockTridiagonalArrowhead{
-      makeSparsityStatic<dim, dim>(entries.diag),
-      makeSparsityStatic<dim, dim>(entries.subdiag),
-      makeSparsityStatic<dim_outer, dim>(entries.outer)};
+      SparsityDynamic(dim, dim, entries.diag),
+      SparsityDynamic(dim, dim, entries.subdiag),
+      SparsityDynamic(dim_outer, dim, entries.outer)};
 };
 
 }  // namespace ctldl

--- a/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.test.cpp
+++ b/ctldl/symbolic/filled_in_sparsity_repeating_arrowhead.test.cpp
@@ -14,9 +14,8 @@ namespace {
 BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadEmptyTest) {
   constexpr auto empty = makeEmptySparsityStatic<1, 1>();
   constexpr PermutationStatic<1> permutation{};
-  constexpr auto filled =
-      getFilledInSparsityRepeatingArrowhead<empty, empty, empty, permutation,
-                                            permutation>();
+  constexpr auto filled = getFilledInSparsityRepeatingArrowhead(
+      empty, empty, empty, permutation, permutation);
   CTLDL_TEST_SPARSITY_EQUAL(filled.outer, empty);
 }
 
@@ -27,8 +26,8 @@ BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadFromDiagonalTest) {
   constexpr PermutationStatic<3> permutation{};
   constexpr PermutationStatic<1> permutation_outer{};
   constexpr auto filled =
-      getFilledInSparsityRepeatingArrowhead<sparsity_A, sparsity_B, sparsity_C,
-                                            permutation, permutation_outer>();
+      defineStaticSparsity(getFilledInSparsityRepeatingArrowhead(
+          sparsity_A, sparsity_B, sparsity_C, permutation, permutation_outer));
 
   constexpr auto filled_correct =
       makeSparsityStatic<1, 3>({{0, 0}, {0, 1}, {0, 2}});
@@ -42,8 +41,8 @@ BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadFromBothTest) {
   constexpr PermutationStatic<3> permutation{};
   constexpr PermutationStatic<1> permutation_outer{};
   constexpr auto filled =
-      getFilledInSparsityRepeatingArrowhead<sparsity_A, sparsity_B, sparsity_C,
-                                            permutation, permutation_outer>();
+      defineStaticSparsity(getFilledInSparsityRepeatingArrowhead(
+          sparsity_A, sparsity_B, sparsity_C, permutation, permutation_outer));
 
   constexpr auto filled_correct =
       makeSparsityStatic<1, 3>({{0, 0}, {0, 1}, {0, 2}});
@@ -58,8 +57,8 @@ BOOST_AUTO_TEST_CASE(FilledInSparsityRepeatingArrowheadBackwardsTest) {
   constexpr PermutationStatic<4> permutation{};
   constexpr PermutationStatic<1> permutation_outer{};
   constexpr auto filled =
-      getFilledInSparsityRepeatingArrowhead<sparsity_A, sparsity_B, sparsity_C,
-                                            permutation, permutation_outer>();
+      defineStaticSparsity(getFilledInSparsityRepeatingArrowhead(
+          sparsity_A, sparsity_B, sparsity_C, permutation, permutation_outer));
 
   constexpr auto filled_correct =
       makeSparsityStatic<1, 4>({{0, 0}, {0, 1}, {0, 2}, {0, 3}});

--- a/ctldl/symbolic/get_entries_with_fill.hpp
+++ b/ctldl/symbolic/get_entries_with_fill.hpp
@@ -4,31 +4,16 @@
 #include <ctldl/sparsity/sparsity_csr.hpp>
 #include <ctldl/sparsity/sort_entries_row_major_sorted.hpp>
 #include <ctldl/symbolic/foreach_nonzero_with_fill.hpp>
-#include <ctldl/utility/fix_init_if_zero_length_array.hpp>
 
-#include <array>
 #include <cstddef>
+#include <vector>
 
 namespace ctldl {
 
-constexpr auto getNumNonZerosWithFill(const SparsityViewCSR sparsity) {
-  std::size_t nnz = 0;
-  const auto count_nonzero = [&nnz](const std::size_t /*i*/,
-                                    const std::size_t /*j*/) { nnz += 1; };
-  foreachNonZeroWithFill(sparsity, count_nonzero);
-  return nnz;
-}
-
-template <auto sparsity>
-constexpr auto getEntriesWithFill() {
-  constexpr auto nnz = getNumNonZerosWithFill(sparsity);
-  std::array<Entry, nnz> entries;
-  fixInitIfZeroLengthArray(entries);
-  std::size_t entry_index = 0;
-  const auto add_entry = [&entries, &entry_index](const std::size_t i,
-                                                  const std::size_t j) {
-    entries[entry_index] = Entry{i, j};
-    entry_index += 1;
+constexpr auto getEntriesWithFill(const SparsityViewCSR sparsity) {
+  std::vector<Entry> entries;
+  const auto add_entry = [&entries](const std::size_t i, const std::size_t j) {
+    entries.push_back(Entry{i, j});
   };
   foreachNonZeroWithFill(sparsity, add_entry);
   // sorting is not needed for correctness, but helps performance

--- a/ctldl/symbolic/is_chordal_blocked.hpp
+++ b/ctldl/symbolic/is_chordal_blocked.hpp
@@ -19,11 +19,11 @@ constexpr bool isChordalBlocked(const SparsityViewCSR sparsity11,
   if (!isLowerTriangle(sparsity11) || !isLowerTriangle(sparsity22)) {
     return false;
   }
-  const auto nnz_filled =
-      getFilledInNumNonZerosBlocked(sparsity11, sparsity21, sparsity22);
-  return nnz_filled.block11 == sparsity11.nnz() &&
-         nnz_filled.block21 == sparsity21.nnz() &&
-         nnz_filled.block22 == sparsity22.nnz();
+  const auto filled =
+      getFilledInSparsityBlocked(sparsity11, sparsity21, sparsity22);
+  return filled.block11.nnz() == sparsity11.nnz() &&
+         filled.block21.nnz() == sparsity21.nnz() &&
+         filled.block22.nnz() == sparsity22.nnz();
 };
 
 }  // namespace ctldl

--- a/ctldl/symbolic/lower_triangle_blocked.hpp
+++ b/ctldl/symbolic/lower_triangle_blocked.hpp
@@ -1,31 +1,45 @@
 #pragma once
 
+#include <ctldl/sparsity/sparsity.hpp>
+
 namespace ctldl {
 
-template <class T11, class T21, class T22, class T31, class T32, class T33>
+template <class T>
 struct LowerTriangleBlocked3x3 {
-  using Block11 = T11;
-  using Block21 = T21;
-  using Block22 = T22;
-  using Block31 = T31;
-  using Block32 = T32;
-  using Block33 = T33;
-  Block11 block11;
-  Block21 block21;
-  Block22 block22;
-  Block31 block31;
-  Block32 block32;
-  Block33 block33;
+  T block11;
+  T block21;
+  T block22;
+  T block31;
+  T block32;
+  T block33;
 };
 
-template <class T11, class T21, class T22>
+consteval auto defineStaticSparsity(
+    const LowerTriangleBlocked3x3<SparsityDynamic>& sparsity) {
+  return LowerTriangleBlocked3x3{
+      defineStaticSparsity(sparsity.block11),
+      defineStaticSparsity(sparsity.block21),
+      defineStaticSparsity(sparsity.block22),
+      defineStaticSparsity(sparsity.block31),
+      defineStaticSparsity(sparsity.block32),
+      defineStaticSparsity(sparsity.block33),
+  };
+}
+
+template <class T>
 struct LowerTriangleBlocked {
-  using Block11 = T11;
-  using Block21 = T21;
-  using Block22 = T22;
-  Block11 block11;
-  Block21 block21;
-  Block22 block22;
+  T block11;
+  T block21;
+  T block22;
 };
+
+consteval auto defineStaticSparsity(
+    const LowerTriangleBlocked<SparsityDynamic>& sparsity) {
+  return LowerTriangleBlocked{
+      defineStaticSparsity(sparsity.block11),
+      defineStaticSparsity(sparsity.block21),
+      defineStaticSparsity(sparsity.block22),
+  };
+}
 
 }  // namespace ctldl

--- a/ctldl/symbolic/repeating_block_tridiagonal_arrowhead.hpp
+++ b/ctldl/symbolic/repeating_block_tridiagonal_arrowhead.hpp
@@ -1,16 +1,23 @@
 #pragma once
 
+#include <ctldl/sparsity/sparsity.hpp>
+
 namespace ctldl {
 
-template <class Diagonal, class Subdiagonal, class Outer>
+template <class T>
 struct RepeatingBlockTridiagonalArrowhead {
-  Diagonal diag;
-  Subdiagonal subdiag;
-  Outer outer;
+  T diag;
+  T subdiag;
+  T outer;
 };
 
-template <class Diagonal, class Subdiagonal, class Outer>
-RepeatingBlockTridiagonalArrowhead(Diagonal, Subdiagonal, Outer)
-    -> RepeatingBlockTridiagonalArrowhead<Diagonal, Subdiagonal, Outer>;
+consteval auto defineStaticSparsity(
+    const RepeatingBlockTridiagonalArrowhead<SparsityDynamic>& sparsity) {
+  return RepeatingBlockTridiagonalArrowhead{
+      defineStaticSparsity(sparsity.diag),
+      defineStaticSparsity(sparsity.subdiag),
+      defineStaticSparsity(sparsity.outer),
+  };
+}
 
 }  // namespace ctldl

--- a/tests/utility/test_sparsity_equal.hpp
+++ b/tests/utility/test_sparsity_equal.hpp
@@ -7,10 +7,15 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <meta>
+#include <ranges>
+#include <vector>
+
 #define CTLDL_TEST_SPARSITY_EQUAL(sparsity_lhs, sparsity_rhs)         \
   CTLDL_TEST_STATIC(isSparsityEqual((sparsity_lhs), (sparsity_rhs))); \
   {                                                                   \
-    const auto sortedEntries = [](auto entries) {                     \
+    const auto sortedEntries = [](auto entries_init) {                \
+      auto entries = entries_init | std::ranges::to<std::vector>();   \
       sortEntriesRowMajorSorted(entries);                             \
       return entries;                                                 \
     };                                                                \


### PR DESCRIPTION
Instead of returning SparsityStatic which requires inputs to be passed as non-type template parameters, return SparsityDynamic and lift to static storage with `std::define_static_array`